### PR TITLE
Fix the csv renderer and small perf on samples endpoint.

### DIFF
--- a/emgapi/renderers.py
+++ b/emgapi/renderers.py
@@ -63,7 +63,8 @@ class CSVStreamingRenderer(CSVRenderer):
         total = queryset.count()
         page_size = 25
 
-        header_fields = list(serializer(queryset.first(), context=context).fields)
+        header_fields = list(serializer(queryset.first(),
+                             context=context).fields)
         yield csv_writer.writerow(header_fields)
 
         for page in range(0, math.ceil(total / page_size)):

--- a/emgapi/renderers.py
+++ b/emgapi/renderers.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+import json
 import csv
 
 from rest_framework import renderers
@@ -21,6 +23,7 @@ from rest_framework.compat import six
 from rest_framework_json_api.renderers import JSONRenderer
 from rest_framework_csv.renderers import CSVRenderer
 from rest_framework_csv.misc import Echo
+from rest_framework.utils.serializer_helpers import ReturnDict
 
 
 class DefaultJSONRenderer(JSONRenderer):
@@ -41,6 +44,15 @@ class CSVStreamingRenderer(CSVRenderer):
 
     def render(self, data, media_type=None, renderer_context={}):
 
+        csv_buffer = Echo()
+        csv_writer = csv.writer(csv_buffer)
+
+        if isinstance(data, ReturnDict):
+            yield csv_writer.writerow(data.keys())
+            flat_row = self.flatten([data[column] for column in data.keys()])
+            yield csv_writer.writerow(flat_row)
+            return
+
         try:
             queryset = data['queryset']
             serializer = data['serializer']
@@ -48,19 +60,30 @@ class CSVStreamingRenderer(CSVRenderer):
         except KeyError:
             return None
 
-        csv_buffer = Echo()
-        csv_writer = csv.writer(csv_buffer)
+        total = queryset.count()
+        page_size = 25
 
-        header_fields = list()
-        for item in queryset:
-            if len(header_fields) < 1:
-                header_fields = list(serializer(item, context=context).fields)
-                yield csv_writer.writerow(header_fields)
-            items = serializer(item, context=context).data
-            ordered = [items[column] for column in header_fields]
-            yield csv_writer.writerow([
-                elem for elem in ordered
-            ])
+        header_fields = list(serializer(queryset.first(), context=context).fields)
+        yield csv_writer.writerow(header_fields)
+
+        for page in range(0, math.ceil(total / page_size)):
+            for item in queryset[page * page_size:(page + 1) * page_size]:
+                items = serializer(item, context=context).data
+                ordered = [items[column] for column in header_fields]
+                yield csv_writer.writerow(self.flatten(ordered))
+
+    def flatten(self, rowdata):
+        """
+        Flatten the data.
+        Used to represent nested fields as json
+        """
+        new_row = []
+        for elem in rowdata:
+            if type(elem) is list or type(elem) is tuple:
+                new_row.append(json.dumps(elem))
+            else:
+                new_row.append(elem)
+        return new_row
 
 
 class TSVRenderer(CSVRenderer):

--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -46,6 +46,7 @@ from . import viewsets as emg_viewsets
 from . import utils as emg_utils
 from . import renderers as emg_renderers
 
+from emgcli.pagination import FasterCountPagination
 
 from emgena import models as ena_models
 from emgena import serializers as ena_serializers
@@ -459,6 +460,7 @@ class SampleViewSet(mixins.RetrieveModelMixin,
 
     lookup_field = 'accession'
     lookup_value_regex = '[^/]+'
+    pagination_class = FasterCountPagination
 
     def get_queryset(self):
         queryset = emg_models.Sample.objects \

--- a/emgcli/pagination.py
+++ b/emgcli/pagination.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright 2017 EMBL - European Bioinformatics Institute
+# Copyright 2019 EMBL - European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,32 @@
 # limitations under the License.
 
 from rest_framework_json_api import pagination
+from django.core.paginator import Paginator
+from django.utils.functional import cached_property
 
 
 class DefaultPagination(pagination.PageNumberPagination):
 
     page_size = 25
     max_page_size = 250
+
+
+class FasterDjangoPaginator(Paginator):
+    """
+    DjangoPaginator override.
+    This class overrides the count method, selecting only the PK
+    this makes the count faster as it doesn't need to fetch all
+    the cols just to do a count.
+    """
+
+    @cached_property
+    def count(self):
+        # Only get the pk to make the pagination faster
+        return self.object_list.values('pk').count()
+
+
+class FasterCountPagination(pagination.PageNumberPagination):
+
+    page_size = 25
+    max_page_size = 250
+    django_paginator_class = FasterDjangoPaginator


### PR DESCRIPTION
Paginate the CSV results for the CSV renderer, and fix for single elements.

Added a simple paginator on the samples endpoint that is faster because
it just returns the pk for the count (useful for complex queries)