### PR TITLE
Consent RT tickets sent to ENA Queue.

### DIFF
--- a/emgena/models.py
+++ b/emgena/models.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2018 EMBL - European Bioinformatics Institute
@@ -84,7 +83,7 @@ class SubmitterContact(models.Model):
 
 class Notify(object):
     def __init__(self, **kwargs):
-        for field in ('id', 'from_email', 'message', 'subject'):
+        for field in ('id', 'from_email', 'message', 'subject', 'is_consent'):
             setattr(self, field, kwargs.get(field, None))
 
 

--- a/emgena/serializers.py
+++ b/emgena/serializers.py
@@ -62,19 +62,37 @@ class NotifySerializer(serializers.Serializer):
     from_email = serializers.EmailField(max_length=200, required=True)
     subject = serializers.CharField(max_length=500, required=True)
     message = serializers.CharField(max_length=1000, required=True)
+    is_consent = serializers.BooleanField(default=False, required=False)
 
     def create(self, validated_data):
+        """Create an RT ticket.
+        If this is a consent aproval then the proceruse is:
+        - create ticket in ENA-MG queue
+        - add EMG email in CC (to link the tickets)
+        otherwise:
+        - create ticket in EMG queue
+        """
         import requests
         n = ena_models.Notify(**validated_data)
 
+        emg_queue = settings.RT["emg_queue"]
+        emg_email = settings.RT["emg_email"]
+        ena_queue = settings.RT["ena_queue"]
+
         ticket = {
             "id": "ticket/new",
-            "Queue": settings.RT['queue'],
             "Requestor": n.from_email,
             "Priority": "4",
             "Subject": n.subject,
             "Text": n.message.replace("\n", ';')
         }
+
+        if n.is_consent:
+            ticket["Queue"] = ena_queue
+            ticket["CC"] = emg_email
+        else:
+            ticket["Queue"] = emg_queue
+
         logger.info("Ticket %r" % ticket)
 
         content = [

--- a/emgena/serializers.py
+++ b/emgena/serializers.py
@@ -66,7 +66,7 @@ class NotifySerializer(serializers.Serializer):
 
     def create(self, validated_data):
         """Create an RT ticket.
-        If this is a consent aproval then the proceruse is:
+        If this is a consent approval then the procedure is:
         - create ticket in ENA-MG queue
         - add EMG email in CC (to link the tickets)
         otherwise:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ jsonapi-client==0.9.8
 pytest-cov==2.8.1
 # For testing webuploader features (under emgapianns/management/commands/...)
 pandas==0.25.2
+responses==0.10.15

--- a/tests/api/test_csv_rendered.py
+++ b/tests/api/test_csv_rendered.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2019 EMBL - European Bioinformatics Institute
+# Copyright 2020 EMBL - European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,14 @@ def pytest_configure():
     settings.DEBUG = False
     settings.ALLOWED_HOSTS = ["*"]
     settings.REST_FRAMEWORK['TEST_REQUEST_DEFAULT_FORMAT'] = 'vnd.api+json'
+    settings.RT = {
+        "url": "https://fake.helpdesk.ebi.ac.uk/REST/1.0/ticket/new",
+        "user": "metagenomics-help-api-user",
+        "pass": "secret-password",
+        "emg_queue": "EMG_Q",
+        "emg_email": "EMG@mail.com",
+        "ena_queue": "ENA_Q"
+    }
     # TODO: backend mock to replace FakeEMGBackend
     # settings.EMG_BACKEND_AUTH_URL = 'http://fake_backend/auth'
     settings.AUTHENTICATION_BACKENDS = ('test_utils.FakeEMGBackend',)

--- a/tests/test_utils/emg_fixtures.py
+++ b/tests/test_utils/emg_fixtures.py
@@ -48,6 +48,7 @@ def biome():
         lineage='root:foo:bar',
     )
 
+
 @pytest.fixture
 def biome_human():
     return emg_models.Biome.objects.create(

--- a/tests/webuploader/test_notify.py
+++ b/tests/webuploader/test_notify.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from urllib.parse import urlencode
 
 from django.core.urlresolvers import reverse
@@ -41,6 +43,7 @@ class TestNotify(APITestCase):
         return token
 
     @responses.activate
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_notify_not_consent(self):
         """Test notify endpoint for non-consent requests
         """
@@ -80,6 +83,7 @@ class TestNotify(APITestCase):
         assert call.request.body == urlencode(expected_body)
 
     @responses.activate
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
     def test_notify_consent(self):
         """Test notify endpoint for consent requests
         """

--- a/tests/webuploader/test_notify.py
+++ b/tests/webuploader/test_notify.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from urllib.parse import urlencode
+
+from django.core.urlresolvers import reverse
+from django.conf import settings
+
+from rest_framework.test import APITestCase
+
+import pytest
+import responses
+
+from test_utils.emg_fixtures import *  # noqa
+
+
+@pytest.mark.django_db
+class TestNotify(APITestCase):
+
+    def get_token(self):
+        data = {
+            'username': 'username',
+            'password': 'secret',
+        }
+
+        rsp = self.client.post(
+            reverse('obtain_jwt_token_v1'), data=data, format='json')
+        token = rsp.json()['data']['token']
+        return token
+
+    @responses.activate
+    def test_notify_not_consent(self):
+        """Test notify endpoint for non-consent requests
+        """
+        expected_body = {
+            "user": "metagenomics-help-api-user",
+            "pass": "secret-password",
+            "content": "\n".join([
+                "id: ticket/new",
+                "Requestor: fake@email.com",
+                "Priority: 4",
+                "Subject: Test email subject",
+                "Text: Hi this is just an example",
+                "Queue: " + settings.RT["emg_queue"]
+            ])
+        }
+
+        responses.add(
+            responses.POST,
+            settings.RT["url"],
+            status=200)
+
+        post_data = {
+            "from_email": "fake@email.com",
+            "subject": "Test email subject",
+            "message": "Hi this is just an example"
+        }
+
+        self.client.post(
+            reverse('emgapi_v1:csrf-notify'),
+            data=post_data, format='json',
+            HTTP_AUTHORIZATION='Bearer {}'.format(self.get_token())
+        )
+
+        assert len(responses.calls) == 1
+        call = responses.calls[0]
+        assert call.request.url == settings.RT["url"]
+        assert call.request.body == urlencode(expected_body)
+
+    @responses.activate
+    def test_notify_consent(self):
+        """Test notify endpoint for consent requests
+        """
+        expected_body = {
+            "user": "metagenomics-help-api-user",
+            "pass": "secret-password",
+            "content": "\n".join([
+                "id: ticket/new",
+                "Requestor: fake@email.com",
+                "Priority: 4",
+                "Subject: Test email subject",
+                "Text: Hi this is just an example",
+                "Queue: " + settings.RT["ena_queue"],
+                "CC: " + settings.RT["emg_email"]
+            ])
+        }
+
+        responses.add(
+            responses.POST,
+            settings.RT["url"],
+            status=200)
+
+        post_data = {
+            "from_email": "fake@email.com",
+            "subject": "Test email subject",
+            "message": "Hi this is just an example",
+            "is_consent": True
+        }
+
+        self.client.post(
+            reverse('emgapi_v1:csrf-notify'),
+            data=post_data, format='json',
+            HTTP_AUTHORIZATION='Bearer {}'.format(self.get_token())
+        )
+
+        assert len(responses.calls) == 1
+        call = responses.calls[0]
+        assert call.request.url == settings.RT["url"]
+        assert call.request.body == urlencode(expected_body)


### PR DESCRIPTION
RT Tickets API rule:
If this is a consent approval then the procedure is:

- create ticket in ENA-MG queue
- add EMG email in CC (to link the tickets)

otherwise:
- create ticket in EMG queue

Tested in DEV env.