### PR TITLE
Mongo contigs disable auto index creation.

### DIFF
--- a/emgapianns/models.py
+++ b/emgapianns/models.py
@@ -386,8 +386,8 @@ class AnalysisJobContig(mongoengine.Document):
     """An analysis job contig, this is used on assemblies
     """
 
-    contig_id = mongoengine.StringField(required=True)
-    # FIXME: this is breaking the API - unique_with=['accession', 'pipeline_version'])
+    contig_id = mongoengine.StringField(required=True,
+                                        unique_with=['accession', 'pipeline_version'])
 
     length = mongoengine.IntField()
     coverage = mongoengine.FloatField()
@@ -414,30 +414,29 @@ class AnalysisJobContig(mongoengine.Document):
     has_antismash = mongoengine.BooleanField(default=False)
     has_kegg_module = mongoengine.BooleanField(default=False)
 
-    # FIXME: this is breaking the API
-    #        it's trying to create the indexes each time.
-    # meta = {
-    #     'indexes': [
-    #         'contig_id',
-    #         'analysis_id',
-    #         'accession',
-    #         'job_id',
-    #         'pipeline_version',
-    #         'length',  # ordering
-    #         'coverage',  # ordering
-    #         'cogs.cog',
-    #         'keggs.ko',
-    #         'gos.go_term',
-    #         'pfams.pfam_entry',
-    #         'interpros.interpro_identifier',
-    #         'as_geneclusters.gene_cluster',
-    #         'kegg_modules.module',
-    #         'has_cog',
-    #         'has_kegg',
-    #         'has_go',
-    #         'has_pfam',
-    #         'has_interpro',
-    #         'has_antismash',
-    #         'has_kegg_module',
-    #     ]
-    # }
+    meta = {
+        'auto_create_index': False,
+        'indexes': [
+            'contig_id',
+            'analysis_id',
+            'accession',
+            'job_id',
+            'pipeline_version',
+            'length',  # ordering
+            'coverage',  # ordering
+            'cogs.cog',
+            'keggs.ko',
+            'gos.go_term',
+            'pfams.pfam_entry',
+            'interpros.interpro_identifier',
+            'as_geneclusters.gene_cluster',
+            'kegg_modules.module',
+            'has_cog',
+            'has_kegg',
+            'has_go',
+            'has_pfam',
+            'has_interpro',
+            'has_antismash',
+            'has_kegg_module',
+        ]
+    }


### PR DESCRIPTION
Indexes for contigs are managed separately (due to the size of the
collection).

auto_create_index=False will prevent mongo from checking if the
indexes match the meta of the class. If manually managed then
the names or order the keys maybe slightly different.