### PR TITLE
Mongo contigs disable auto index creation.

### DIFF
--- a/emgapianns/models.py
+++ b/emgapianns/models.py
@@ -414,6 +414,7 @@ class AnalysisJobContig(mongoengine.Document):
     has_kegg_module = mongoengine.BooleanField(default=False)
 
     meta = {
+        'auto_create_index': False,
         'indexes': [
             'contig_id',
             'analysis_id',


### PR DESCRIPTION
Indexes for contigs are managed separately (due to the size of the
collection).

auto_create_index=False will prevent mongo from checking if the
indexes match the meta of the class. If manually managed then
the names or order the keys maybe slightly different.