### PR TITLE
Jenkings + py3.4 tests run support

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,11 @@
-multidict==4.7.4
-pytest==5.3.5
-pytest-django==3.8.0
+# py3.4
+multidict==4.5.2; python_version < '3.5'
+pytest==4.6.11; python_version < '3.5'
+
+multidict==4.7.4; python_version > '3.4'
+pytest==5.3.5; python_version > '3.4'
+
+pytest-django==3.10.0
 pytest-xdist==1.31.0
 model_bakery==1.1.0
 mock_services==0.3.1
@@ -8,5 +13,7 @@ mongomock==3.19.0
 jsonapi-client==0.9.8
 pytest-cov==2.8.1
 # For testing webuploader features (under emgapianns/management/commands/...)
-pandas==0.25.2
-responses==0.10.15
+# web uploader not tested for python 3.4
+pandas==0.25.2; python_version > '3.4'
+responses==0.10.15; python_version > '3.4'
+jsonapi-client==0.9.8; python_version > '3.4'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def mongodb(request):
         # instance there yet.
         # This will be removed when we drop support for py3.4
         db = mongomock.MongoClient()
-    else
+    else:
         # real mongo connection
         db = mongoengine.connect('testdb')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,9 +79,10 @@ def mongodb(request):
         # Jenkins, we don't have a running mongo
         # instance there yet.
         # This will be removed when we drop support for py3.4
-        return mongomock.MongoClient()
-    
-    db = mongoengine.connect('testdb')
+        db = mongomock.MongoClient()
+    else
+        # real mongo connection
+        db = mongoengine.connect('testdb')
 
     def finalizer():
         db.drop_database('testdb')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ import os
 import pytest
 
 import mongoengine
+import mongomock
 
 from django.conf import settings
 
@@ -72,6 +73,14 @@ def django_db_setup(hide_ena_config, django_db_setup):
 def mongodb(request):
     """On the EMG_CONFIG use 'testdb' on the mongo configuration
     """
+    if os.environ.get("JENKINS", False):
+        # TEMP py3.4
+        # patch to run a fake mongo db on
+        # Jenkins, we don't have a running mongo
+        # instance there yet.
+        # This will be removed when we drop support for py3.4
+        return mongomock.MongoClient()
+    
     db = mongoengine.connect('testdb')
 
     def finalizer():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ import os
 import pytest
 
 import mongoengine
-import mongomock
 
 from django.conf import settings
 
@@ -79,7 +78,7 @@ def mongodb(request):
         # Jenkins, we don't have a running mongo
         # instance there yet.
         # This will be removed when we drop support for py3.4
-        db = mongomock.MongoClient()
+        db = monoengine.connect('testdb', host='mongomock://localhost')
     else:
         # real mongo connection
         db = mongoengine.connect('testdb')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def mongodb(request):
         # Jenkins, we don't have a running mongo
         # instance there yet.
         # This will be removed when we drop support for py3.4
-        db = monoengine.connect('testdb', host='mongomock://localhost')
+        db = mongoengine.connect('testdb', host='mongomock://localhost')
     else:
         # real mongo connection
         db = mongoengine.connect('testdb')


### PR DESCRIPTION
Changes required to run the API test suite in py3.4 in Jenkins.