### PR TITLE
Unambiguous Ordering Filter

### DIFF
--- a/emgapi/filters.py
+++ b/emgapi/filters.py
@@ -30,6 +30,8 @@ from django_filters import widgets
 from . import models as emg_models
 from . import utils as emg_utils
 
+from rest_framework import filters as drf_filters
+
 
 WORD_MATCH_REGEX = r"{0}"
 FLOAT_MATCH_REGEX = r"^[0-9 \.\,]+$"
@@ -1059,3 +1061,17 @@ class GenomeFilter(django_filters.FilterSet):
             "pangenome_accessory_size__gte",
             "pangenome_accessory_size__lte",
         )
+
+def getUnambiguousOrderingFilterByField(field):
+    class UnambiguousOrderingFilter(drf_filters.OrderingFilter):
+        def filter_queryset(self, request, queryset, view):
+            ordering = self.get_ordering(request, queryset, view)
+
+            if ordering:
+                if field in ordering:
+                    return queryset.order_by(*ordering)
+                else:
+                    return queryset.order_by(*ordering, field)
+
+            return queryset
+    return UnambiguousOrderingFilter

--- a/emgapi/serializers.py
+++ b/emgapi/serializers.py
@@ -1195,7 +1195,7 @@ class StudySerializer(ExplicitFieldsModelSerializer,
         return emg_models.Biome.objects \
             .filter(pk__in=biomes)
 
-    publications = relations.SerializerMethodHyperlinkedRelatedField(
+    publications = emg_relations.HyperlinkedSerializerMethodResourceRelatedField(
         source='get_publications',
         model=emg_models.Publication,
         many=True,
@@ -1206,6 +1206,8 @@ class StudySerializer(ExplicitFieldsModelSerializer,
     )
 
     def get_publications(self, obj):
+        if 'publications' in utils.get_included_resources(self.context['request']):
+            return obj.publications.all()
         return None
 
     downloads = relations.SerializerMethodHyperlinkedRelatedField(

--- a/emgapi/views_relations.py
+++ b/emgapi/views_relations.py
@@ -318,7 +318,7 @@ class StudyAnalysisResultViewSet(emg_mixins.ListModelMixin,
 
     filter_backends = (
         DjangoFilterBackend,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('job_id'),
     )
 
     ordering_fields = (

--- a/emgapi/viewsets.py
+++ b/emgapi/viewsets.py
@@ -92,7 +92,7 @@ class BaseSampleGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        emg_filters.getUnambiguousOrderingFilterByField('sample_id'),
+        emg_filters.getUnambiguousOrderingFilterByField('accession'),
     )
 
     ordering_fields = (

--- a/emgapi/viewsets.py
+++ b/emgapi/viewsets.py
@@ -61,7 +61,7 @@ class BaseStudyGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('study_id'),
     )
 
     ordering_fields = (

--- a/emgapi/viewsets.py
+++ b/emgapi/viewsets.py
@@ -36,7 +36,7 @@ class BaseSuperStudyViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('super_study_id'),
     )
 
     ordering_fields = (
@@ -92,7 +92,7 @@ class BaseSampleGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('sample_id'),
     )
 
     ordering_fields = (
@@ -127,7 +127,7 @@ class BaseRunGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('run_id'),
     )
 
     ordering_fields = (
@@ -155,7 +155,7 @@ class BaseAssemblyGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('assembly_id'),
     )
 
     ordering_fields = (
@@ -181,7 +181,7 @@ class BaseAnalysisGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('job_id'),
     )
 
     ordering_fields = (
@@ -214,7 +214,7 @@ class BasePublicationGenericViewSet(viewsets.GenericViewSet):
     filter_backends = (
         DjangoFilterBackend,
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('pubmed_id'),
     )
 
     ordering_fields = (
@@ -242,7 +242,7 @@ class BaseGenomeGenericViewSet(viewsets.GenericViewSet):
 
     filter_backends = (
         filters.SearchFilter,
-        filters.OrderingFilter,
+        emg_filters.getUnambiguousOrderingFilterByField('accession'),
     )
 
     ordering_fields = (

--- a/emgcli/urls.py
+++ b/emgcli/urls.py
@@ -73,7 +73,7 @@ custom_login_view = views.LoginView
 custom_login_view.form_class = CustomAuthenticationForm
 
 urlpatterns = [
-    url(r'^http-auth/login_form$', custom_login_view.as_view(
+    url('http-auth/login_form', custom_login_view.as_view(
         template_name='rest_framework/login_form.html'), {}),
 
     url(r'^http-auth/', include('rest_framework.urls',


### PR DESCRIPTION
The ordering filter was giving different results depending of where the API was running, more than 1 object have the same value on the attribute that a queryset is been ordered by.

The strategy was to create a new Ordering filter that inherits from the default one, and adds an extra field to order by to settle any even cases.

