### PR TITLE
Improves performance of Assemblies endpoint

### DIFF
--- a/emgapi/serializers.py
+++ b/emgapi/serializers.py
@@ -556,7 +556,7 @@ class AssemblySerializer(ExplicitFieldsModelSerializer,
 
     def get_pipelines(self, obj):
         # TODO: push that to queryset
-        return emg_models.Pipeline.objects_annotated \
+        return emg_models.Pipeline.objects \
             .filter(analyses__assembly=obj)
 
     def get_analyses(self, obj):


### PR DESCRIPTION
If `pipelines` were included in the `/assemblies` endpoint (the default behaviour, or by `/assemblies?fields=pipeline`) then the querying was very slow because the related pipelines query set was annotating every object with a `count`. This annotation doesn't seem to actually be serialized by the Assembly serializer or used in the query, so it can seemingly be replaced by the default, non-annotating, Pipeline queryset manager.