### PR TITLE
Fix CSV renderer.

### DIFF
--- a/emgapi/renderers.py
+++ b/emgapi/renderers.py
@@ -14,18 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-import json
-import csv
-
 from rest_framework import renderers
-# from rest_framework.compat import six
 from rest_framework_json_api.renderers import JSONRenderer
-from rest_framework_csv.renderers import CSVRenderer
-from rest_framework_csv.misc import Echo
-from rest_framework.utils.serializer_helpers import ReturnDict
-
-from mongoengine.base.datastructures import BaseList
+from rest_framework_csv.renderers import CSVRenderer, CSVStreamingRenderer as BaseCSVStreamingRenderer
 
 
 class DefaultJSONRenderer(JSONRenderer):
@@ -38,70 +29,17 @@ class JSONLDRenderer(renderers.JSONRenderer):
     format = 'ldjson'
 
 
-class CSVStreamingRenderer(CSVRenderer):
+class CSVStreamingRenderer(BaseCSVStreamingRenderer):
     """
-    Based on rest_framework_csv.renderers.CSVStreamingRenderer,
-    tabilize() call is not iterator-friendly.
+    Based on rest_framework_csv.renderers.CSVStreamingRenderer
+    combined with rest_framework_csv.renderers.PaginatedCSVRenderer
     """
+    results_field = 'results'
 
-    def render(self, data, media_type=None, renderer_context={}):
-
-        csv_buffer = Echo()
-        csv_writer = csv.writer(csv_buffer)
-
-        if isinstance(data, ReturnDict):
-            yield csv_writer.writerow(data.keys())
-            flat_row = self.flatten([data[column] for column in data.keys()])
-            yield csv_writer.writerow(flat_row)
-            return
-
-        try:
-            queryset = data['queryset']
-            serializer = data['serializer']
-            context = data['context']
-        except KeyError:
-            return None
-
-        if isinstance(queryset, BaseList):
-            # Handle SortedListField in the AnnotationModels
-            # TODO: pending review as this has no pagination at the moment
-            if not queryset:
-                return None
-
-            header_fields = list(serializer(queryset[0], context=context).fields)
-            yield csv_writer.writerow(header_fields)
-
-            for item in queryset:
-                items = serializer(item, context=context).data
-                ordered = [items[column] for column in header_fields]
-                yield csv_writer.writerow(self.flatten(ordered))
-            return
-
-        total = queryset.count()
-        page_size = 25
-
-        header_fields = list(serializer(queryset.first(),
-                             context=context).fields)
-        yield csv_writer.writerow(header_fields)
-
-        for page in range(0, math.ceil(total / page_size)):
-            for item in queryset[page * page_size:(page + 1) * page_size]:
-                items = serializer(item, context=context).data
-                ordered = [items[column] for column in header_fields]
-                yield csv_writer.writerow(self.flatten(ordered))
-
-    def flatten(self, rowdata):
-        """
-        Flatten the data.
-        Used to represent nested fields as json
-        """
-        new_row = []
-        for elem in rowdata:
-            if type(elem) is list or type(elem) is tuple:
-                new_row.append(json.dumps(elem))
-            else:
-                new_row.append(elem)
-        return new_row
+    def render(self, data, *args, **kwargs):
+        if not isinstance(data, list):
+            data = data.get(self.results_field, [])
+        return super(CSVStreamingRenderer, self).render(data, *args, **kwargs)
 
 
 class TSVRenderer(CSVRenderer):

--- a/tests/api/test_study.py
+++ b/tests/api/test_study.py
@@ -68,3 +68,14 @@ class TestStudyAPI:
         assert d['type'] == "studies"
         assert d['id'] == "MGYS00001234"
         assert d['attributes']['accession'] == "MGYS00001234"
+
+    def test_csv(self, client, studies):
+        url = reverse("emgapi_v1:studies-list", kwargs={'format': 'csv'})
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.get('Content-Disposition') == 'attachment; filename="Study.csv"'
+        content = b''.join(response.streaming_content).decode('utf-8')
+        assert 'accession' in content
+        assert '00001' in content
+        assert '00049' in content
+        assert content.count('HARVESTED') == 49

--- a/tests/api/test_study.py
+++ b/tests/api/test_study.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import pytest
 
 from django.urls import reverse
@@ -75,7 +74,43 @@ class TestStudyAPI:
         assert response.status_code == status.HTTP_200_OK
         assert response.get('Content-Disposition') == 'attachment; filename="Study.csv"'
         content = b''.join(response.streaming_content).decode('utf-8')
-        assert 'accession' in content
-        assert '00001' in content
-        assert '00049' in content
-        assert content.count('HARVESTED') == 49
+
+        expected_header = ",".join([
+            "accession",
+            "analyses",
+            "bioproject",
+            "centre_name",
+            "data_origination",
+            "is_public",
+            "last_update",
+            "public_release_date",
+            "publications",
+            "samples_count",
+            "secondary_accession",
+            "study_abstract",
+            "study_name",
+            "url"
+        ])
+        first_row = ",".join([
+            "MGYS00000001",
+            "",
+            "PRJDB0001",
+            "Centre Name",
+            "HARVESTED",
+            "True",
+            "1970-01-01T00:00:00",
+            "",
+            "",
+            "",
+            "SRP0001",
+            "",
+            "Example study name 1",
+            "http://testserver/v1/studies/MGYS00000001.csv"
+        ])
+
+        rows = content.splitlines()
+
+        assert len(rows) == 50
+
+        assert expected_header == rows[0]
+        assert first_row == rows[1]


### PR DESCRIPTION
This PR:
- Fixes the streaming CSV renderer, which was probably broken during Django 3 migration and related updates to DRF and `djangorestframework-csv`.
  - Removes most of our custom code for that.
  - Maintains CSV as unpaginated.
  - Switches to the library-provided data flatteners which seem to give more usable outputs.
- Adds a basic unit test for the CSV on Studies endpoint.
---
No migrations or perms changes.