### PR TITLE
Prevent timeouts when CSV'ing long querysets

### DIFF
--- a/emgapi/mixins.py
+++ b/emgapi/mixins.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.http.response import StreamingHttpResponse
+from rest_framework.exceptions import APIException
+from rest_framework.renderers import BrowsableAPIRenderer
 
 from rest_framework.response import Response
 
 from emgapi.renderers import CSVStreamingRenderer
+from rest_framework_json_api.renderers import JSONRenderer
 
 
 class MultipleFieldLookupMixin(object):
@@ -27,6 +31,14 @@ class MultipleFieldLookupMixin(object):
         return get_object_or_404(queryset, **filter)
 
 
+class ExcessiveCSVException(APIException):
+    status_code = 413
+    default_detail = 'The requested data is too long to be returned as a single CSV. ' \
+                     'Please use the API to fetch paginated data. ' \
+                     'E.g. https://gist.github.com/SandyRogers/5d9eff7f1f7b08cfa40265f5e2adf9cd'
+    default_code = 'payload_too_large'
+
+
 class ListModelMixin(object):
     """
     List a queryset.
@@ -35,6 +47,17 @@ class ListModelMixin(object):
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         if isinstance(request.accepted_renderer, CSVStreamingRenderer):
+
+            if queryset.count() > 50 * settings.EMG_DEFAULT_LIMIT:
+                # More than 50 pages of results will probably timeout
+                # (for a complicated endpoint like Studies).
+                # Return custom exception detailing use of paginated API.
+                if request.accepts('text/html'):
+                    request.accepted_renderer = BrowsableAPIRenderer()
+                else:
+                    request.accepted_renderer = JSONRenderer()
+                raise ExcessiveCSVException
+
             try:
                 filename = queryset.model.__name__
             except AttributeError:


### PR DESCRIPTION
We return unpaginated responses when a resource list is requested as CSV. This is intended functionality. This is fine for short query sets but long ones hit an nginx timeout.

This fix overrides the response, if the queryset is big, and returns an error with an instruction to use the (paginated) API to access these data.

Response is JSON, unless the client accepts HTML in which case it is the Browsable API (html) page with the error. So users of the API Browser will see a pretty error, users of scripts/curl etc will see some short JSON. 