### PR TITLE
Multiple emails

### DIFF
--- a/emgena/models.py
+++ b/emgena/models.py
@@ -83,7 +83,7 @@ class SubmitterContact(models.Model):
 
 class Notify(object):
     def __init__(self, **kwargs):
-        for field in ('id', 'from_email', 'message', 'subject', 'is_consent'):
+        for field in ('id', 'from_email', 'message', 'subject', 'is_consent', 'cc'):
             setattr(self, field, kwargs.get(field, None))
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ _base = os.path.dirname(os.path.abspath(__file__))
 _requirements = os.path.join(_base, 'requirements.txt')
 _requirements_test = os.path.join(_base, 'requirements-test.txt')
 
-version = "1.8.3"
+version = "1.8.4"
 
 install_requirements = []
 with open(_requirements) as f:

--- a/tests/webuploader/test_notify.py
+++ b/tests/webuploader/test_notify.py
@@ -64,7 +64,6 @@ class TestNotify(APITestCase):
             responses.POST,
             settings.RT["url"],
             status=200)
-
         post_data = {
             "from_email": "fake@email.com",
             "subject": "Test email subject",


### PR DESCRIPTION
* Notify serializer supporting comma separated emails in from_email
* support for CC when opening a ticket
* CC field in notifications is optional
* notification: only validate field if in initial_data
* Notification: cc is not required
* Update emgena/serializers.py
* strip email when validating notifications