### PR TITLE
Enabling fulltext

### DIFF
--- a/emgapi/models.py
+++ b/emgapi/models.py
@@ -1835,3 +1835,17 @@ class GenomeCatalogueDownload(BaseDownload):
         db_table = 'GENOME_CATALOGUE_DOWNLOAD'
         unique_together = (('realname', 'alias'),)
         ordering = ('group_type', 'alias')
+
+
+class Search(models.Lookup):
+    lookup_name = 'search'
+
+    def as_mysql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        rhs, rhs_params = self.process_rhs(compiler, connection)
+        params = lhs_params + rhs_params
+        return 'MATCH (%s) AGAINST (%s IN BOOLEAN MODE)' % (lhs, rhs), params
+
+
+models.CharField.register_lookup(Search)
+models.TextField.register_lookup(Search)

--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -186,8 +186,8 @@ class MyDataViewSet(emg_mixins.ListModelMixin,
     ordering = ('-last_update',)
 
     search_fields = (
-        'study_name',
-        'study_abstract',
+        '@study_name',
+        '@study_abstract',
         'centre_name',
         'project_id',
     )
@@ -221,7 +221,7 @@ class BiomeViewSet(mixins.RetrieveModelMixin,
     )
 
     search_fields = (
-        'biome_name',
+        '@biome_name',
         'lineage',
     )
 

--- a/emgapi/views_relations.py
+++ b/emgapi/views_relations.py
@@ -839,7 +839,7 @@ class BiomeTreeViewSet(mixins.ListModelMixin,
     )
 
     search_fields = (
-        'biome_name',
+        '@biome_name',
         'lineage',
     )
 

--- a/emgapi/viewsets.py
+++ b/emgapi/viewsets.py
@@ -47,8 +47,8 @@ class BaseSuperStudyViewSet(viewsets.GenericViewSet):
     ordering = ('super_study_id',)
 
     search_fields = (
-        'title',
-        'description',
+        '@title',
+        '@description',
         'url_slug'
     )
 
@@ -75,8 +75,8 @@ class BaseStudyGenericViewSet(viewsets.GenericViewSet):
     ordering = ('-last_update',)
 
     search_fields = (
-        'study_name',
-        'study_abstract',
+        '@study_name',
+        '@study_abstract',
         'study_id',
         'secondary_accession',
         'project_id',
@@ -107,15 +107,15 @@ class BaseSampleGenericViewSet(viewsets.GenericViewSet):
     search_fields = (
         'accession',
         'primary_accession',
-        'sample_name',
-        'sample_desc',
+        '@sample_name',
+        '@sample_desc',
         'sample_alias',
         'species',
         'environment_feature',
         'environment_biome',
         'environment_feature',
         'environment_material',
-        'metadata__var_val_ucv',
+        '@metadata__var_val_ucv',
     )
 
 
@@ -143,7 +143,7 @@ class BaseRunGenericViewSet(viewsets.GenericViewSet):
         'instrument_platform',
         'instrument_model',
         'experiment_type__experiment_type',
-        'sample__metadata__var_val_ucv',
+        '@sample__metadata__var_val_ucv',
     )
 
 
@@ -169,7 +169,7 @@ class BaseAssemblyGenericViewSet(viewsets.GenericViewSet):
         'accession',
         'wgs_accession',
         'legacy_accession',
-        'samples__metadata__var_val_ucv',
+        '@samples__metadata__var_val_ucv',
     )
 
 
@@ -227,8 +227,8 @@ class BasePublicationGenericViewSet(viewsets.GenericViewSet):
     ordering = ('-pubmed_id',)
 
     search_fields = (
-        'pub_title',
-        'pub_abstract',
+        '@pub_title',
+        '@pub_abstract',
         'pub_type',
         'authors',
         'doi',

--- a/emgapianns/views.py
+++ b/emgapianns/views.py
@@ -887,7 +887,7 @@ class OrganismAnalysisRelationshipViewSet(m_viewsets.ListReadOnlyModelViewSet):
     ordering = ('-job_id',)
 
     search_fields = (
-        'sample__metadata__var_val_ucv',
+        '@sample__metadata__var_val_ucv',
     )
 
     lookup_field = 'lineage'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
 # dev tools
-django-debug-toolbar==3.2.1
+django-debug-toolbar==3.2.2
 django-extensions==3.1.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,10 +3,10 @@ multidict==4.5.2; python_version < '3.5'
 pytest==4.6.11; python_version < '3.5'
 
 multidict==5.1.0; python_version > '3.4'
-pytest==6.2.4; python_version > '3.4'
+pytest==6.2.5; python_version > '3.4'
 
 pytest-django==4.4.0
-pytest-xdist==2.2.1
+pytest-xdist==2.3.0
 model_bakery==1.3.2
 mock_services==0.3.1
 mongomock==3.23.0
@@ -14,7 +14,7 @@ jsonapi-client==0.9.9
 pytest-cov==2.12.1
 
 pandas==0.25.3; python_version < '3.7'
-pandas==1.2.3; python_version > '3.6'
+pandas==1.3.2; python_version > '3.6'
 
 responses==0.10.15; python_version < '3.5'
-responses==0.13.3; python_version > '3.4'
+responses==0.13.4; python_version > '3.4'

--- a/requirements-webuploader.txt
+++ b/requirements-webuploader.txt
@@ -5,5 +5,5 @@ ena-api-libs~=1.0.4
 emg-backlog-schema~=1.0.0
 pandas~=0.25.2
 
-django-debug-toolbar==3.2.1
-django-extensions==3.1.2
+django-debug-toolbar==3.2.2
+django-extensions==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,14 @@ gunicorn==19.9.0; python_version < '3.5'
 whitenoise==3.3.1; python_version < '3.5'
 mysqlclient==1.3.13; python_version < '3.5'
 sqlparse==0.2.4; python_version < '3.5'
-requests==2.19.1; python_version < '3.5'
+requests==2.21.0; python_version < '3.5'
 
 gunicorn==20.0.4; python_version > '3.4'
 mysqlclient==1.4.6; python_version > '3.4'
 mysql-connector-python~=8.0.23
 sqlparse==0.3.1; python_version > '3.4'
 whitenoise==5.0.1; python_version > '3.4'
-requests==2.23.0; python_version > '3.4'
+requests==2.26.0; python_version > '3.4'
 
 yamjam==0.1.7
 # python 3.4
@@ -25,21 +25,21 @@ django-slack==5.16.0
 # log handler
 ConcurrentLogHandler~=0.9.1
 
-Django==3.2.4
+Django==3.2.7
 djangorestframework==3.12.4
 django-filter==2.4.0
 djangorestframework-jwt~=1.11.0
-django-cors-headers==3.7.0
+django-cors-headers==3.8.0
 cx_Oracle~=6.2.1
 
 djangorestframework-csv==2.1.1
 
 # schema
-drf-spectacular==0.17.2
+drf-spectacular==0.18.2
 
 # mongo
 mongoengine==0.23.1
-pymongo==3.11.4
+pymongo==3.12.0
 django-rest-framework-mongoengine==3.4.1
 
 # assembly viewer


### PR DESCRIPTION
This enables the `__search` lookup in CharFields and TextFields, which is then used in the same API fields as in the latest version (8baec5ea6067129d6b98f5757b04bb19281f0352) before the Django 3 update.

At the end it was as simple as adding the suggestion from [here](https://docs.djangoproject.com/en/3.2/releases/1.10/#search-lookup-replacement) in the `models.py`. Which uses `__search` lookup as a `BINARY MODE` full text search in MySQL, as seen [here](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html).

It also updates a few dependencies.

