### PR TITLE
API renderer fixes for Analysis>Contigs endpoint

### DIFF
--- a/emgapianns/pagination.py
+++ b/emgapianns/pagination.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 from collections import OrderedDict
 
 from rest_framework_json_api import pagination


### PR DESCRIPTION
This PR:
- fixes [a bug](https://www.ebi.ac.uk/panda/jira/browse/EMG-2471), where the Browsable API renderer did not work for the Contigs listing detail endpoint on an Analysis. 
- removes cursor-based pagination from that Analysis>Contigs endpoint when the renderer is CSV, because there is no standard way to show pagination controls in CSVs. The CSV will return up to 1000 rows ignoring any pagination query parameters, and show an error otherwise. This mirrors the [same change](https://github.com/EBI-Metagenomics/emgapi/pull/223) recently made for non-mongo endpoints. 