### PR TITLE
Additional metadata on Samples via Europe PMC Annotations

### DIFF
--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -48,7 +48,7 @@ from . import viewsets as emg_viewsets
 from . import utils as emg_utils
 from . import renderers as emg_renderers
 from . import filters as emg_filters
-from .europe_pmc import get_publication_annotations
+from .europe_pmc import get_publication_annotations, get_publication_annotations_existence_for_sample
 from .sourmash import validate_sourmash_signature, save_signature, send_sourmash_jobs, get_sourmash_job_status, \
     get_result_file
 
@@ -617,6 +617,21 @@ class SampleViewSet(mixins.RetrieveModelMixin,
         """
         return super(SampleViewSet, self).list(request, *args, **kwargs)
 
+    @action(
+        detail=True,
+        methods=['get', ]
+    )
+    def studies_publications_annotations_existence(self, request, accession=None):
+        """
+        Get a summary of whether a Sample's linked Studies have any Publications which are annotated by Europe PMC.
+
+        Example:
+        ---
+        `/samples/ERS1015417/check_studies_publications_for_annotations`
+        """
+        sample = self.get_object()
+        return Response(data=get_publication_annotations_existence_for_sample(sample))
+
 
 class RunViewSet(mixins.RetrieveModelMixin,
                  emg_mixins.ListModelMixin,
@@ -1169,6 +1184,13 @@ class PublicationViewSet(mixins.RetrieveModelMixin,
         methods=['get', ]
     )
     def europe_pmc_annotations(self, request, pubmed_id=None):
+        """
+        Retrieve Europe PMC Metagenomics annotations for a publication.
+
+        Example:
+        ---
+        `/publications/{pubmed}/europe_pmc_annotations`
+        """
         if not pubmed_id:
             raise Http404
         return Response(data=get_publication_annotations(pubmed_id))


### PR DESCRIPTION
This PR:
- adds an endpoint (a detail action endpoint on Sample) to check whether a Sample might have additional metadata from associated Studies with Europe PMC annotated Publications.

Note that a Sample is related to `s>=0` studies which are each related to `p>=0` publications. So a single endpoint avoids potentially batch-sending many requests to the existing per-publication annotations endpoint.

This new endpoint returns only the existence of annotation, on any publication, for each study. It does not return the annotations.

It makes use of the fact the EPMC can be queried for <=8 publication IDs at one time, and in fact only succeeds if this is the case, to avoid having to send multiple requests to EPMC.

`query_possible` in the response shows whether or not this condition was met (or indeed whether EPMC was down).

In future this could be better handled as an `samples/id?include=studies.publications.annotations` type relationship traversal, but this is not yet possible given the limitations of our implementation of DRF JSON:API.