### PR TITLE
changes to support the RT rest API 2.0

### DIFF
--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -131,7 +131,7 @@ class UtilsViewSet(viewsets.GenericViewSet):
         if serializer.is_valid():
             try:
                 status_code = serializer.save()
-                if status_code == 200:
+                if status_code == 200 or status_code == 201:
                     return Response("Created", status=status.HTTP_201_CREATED)
             except Exception as e:
                 logging.error(e, exc_info=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def pytest_configure():
     settings.RT = {
         "url": "https://fake.helpdesk.ebi.ac.uk/REST/1.0/ticket/new",
         "user": "metagenomics-help-api-user",
-        "pass": "secret-password",
+        "token": "<<TOKEN>>",
         "emg_queue": "EMG_Q",
         "emg_email": "EMG@mail.com",
         "ena_queue": "ENA_Q"

--- a/tests/webuploader/test_notify.py
+++ b/tests/webuploader/test_notify.py
@@ -48,16 +48,11 @@ class TestNotify(APITestCase):
         """Test notify endpoint for non-consent requests
         """
         expected_body = {
-            "user": "metagenomics-help-api-user",
-            "pass": "secret-password",
-            "content": "\n".join([
-                "id: ticket/new",
-                "Requestor: fake@email.com",
-                "Priority: 4",
-                "Subject: Test email subject",
-                "Text: Hi this is just an example",
-                "Queue: " + settings.RT["emg_queue"]
-            ])
+            "Requestor: fake@email.com",
+            "Priority: 4",
+            "Subject: Test email subject",
+            "Text: Hi this is just an example",
+            "Queue: " + settings.RT["emg_queue"]
         }
 
         responses.add(
@@ -87,16 +82,11 @@ class TestNotify(APITestCase):
         """Test notify endpoint for consent requests
         """
         expected_body = {
-            "user": "metagenomics-help-api-user",
-            "pass": "secret-password",
-            "content": "\n".join([
-                "id: ticket/new",
-                "Requestor: fake@email.com",
-                "Priority: 4",
-                "Subject: Test email subject",
-                "Text: Hi this is just an example",
-                "Queue: " + settings.RT["ena_queue"],
-            ])
+            "Requestor: fake@email.com",
+            "Priority: 4",
+            "Subject: Test email subject",
+            "Text: Hi this is just an example",
+            "Queue: " + settings.RT["ena_queue"],
         }
 
         responses.add(

--- a/tests/webuploader/test_notify.py
+++ b/tests/webuploader/test_notify.py
@@ -50,7 +50,7 @@ class TestNotify(APITestCase):
             "Requestor": "fake@email.com",
             "Priority": "4",
             "Subject": "Test email subject",
-            "Text": "Hi this is just an example",
+            "Content": "Hi this is just an example",
             "Queue": settings.RT["emg_queue"]
         }
 
@@ -84,7 +84,7 @@ class TestNotify(APITestCase):
             "Requestor": "fake@email.com",
             "Priority": "4",
             "Subject": "Test email subject",
-            "Text": "Hi this is just an example",
+            "Content": "Hi this is just an example",
             "Queue": settings.RT["ena_queue"],
         }
 

--- a/tests/webuploader/test_notify.py
+++ b/tests/webuploader/test_notify.py
@@ -15,8 +15,6 @@
 
 import sys
 
-from urllib.parse import urlencode
-
 from django.urls import reverse
 from django.conf import settings
 
@@ -24,6 +22,7 @@ from rest_framework.test import APITestCase
 
 import pytest
 import responses
+import json
 
 from test_utils.emg_fixtures import *  # noqa
 
@@ -48,11 +47,11 @@ class TestNotify(APITestCase):
         """Test notify endpoint for non-consent requests
         """
         expected_body = {
-            "Requestor: fake@email.com",
-            "Priority: 4",
-            "Subject: Test email subject",
-            "Text: Hi this is just an example",
-            "Queue: " + settings.RT["emg_queue"]
+            "Requestor": "fake@email.com",
+            "Priority": "4",
+            "Subject": "Test email subject",
+            "Text": "Hi this is just an example",
+            "Queue": settings.RT["emg_queue"]
         }
 
         responses.add(
@@ -74,7 +73,7 @@ class TestNotify(APITestCase):
         assert len(responses.calls) == 1
         call = responses.calls[0]
         assert call.request.url == settings.RT["url"]
-        assert call.request.body == urlencode(expected_body)
+        assert call.request.body == json.dumps(expected_body)
 
     @responses.activate
     @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
@@ -82,11 +81,11 @@ class TestNotify(APITestCase):
         """Test notify endpoint for consent requests
         """
         expected_body = {
-            "Requestor: fake@email.com",
-            "Priority: 4",
-            "Subject: Test email subject",
-            "Text: Hi this is just an example",
-            "Queue: " + settings.RT["ena_queue"],
+            "Requestor": "fake@email.com",
+            "Priority": "4",
+            "Subject": "Test email subject",
+            "Text": "Hi this is just an example",
+            "Queue": settings.RT["ena_queue"],
         }
 
         responses.add(
@@ -110,4 +109,4 @@ class TestNotify(APITestCase):
         assert len(responses.calls) == 1
         call = responses.calls[0]
         assert call.request.url == settings.RT["url"]
-        assert call.request.body == urlencode(expected_body)
+        assert call.request.body == json.dumps(expected_body)


### PR DESCRIPTION
**NOTE:** Only merge this PR once the RT Rest API is updated, which is scheduled for the 2nd week of January.

The code changes in this PR are minimal and basically is just formating the requests to the RT API as a Json, and using a token for authentication.

The token can be created by the RT user once the new version is released.
> To get a token Visit "Logged in as ___" -> Settings -> Auth Tokens. Create an Auth Token, give it any description (such as "REST2 with curl"). Make a note of the authentication token it provides to you and treat this token as you would with your password.

Once you have a token, change the config.yaml removing the password and adding a ticket, for example, for testing purposes you can use `testdesk2` with a configuration like 
```yaml
    url: "https://testdesk2.ebi.ac.uk/REST/2.0/ticket"
    user: "metagenomics-help-testdesk-api-user"
    token: "<<TOKEN>>"
    emg_queue: "metagenomics-help-testdesk"
    ena_queue: "metagenomics-help-testdesk"
```

Successful tests were run using a similar configuration as above, creating tickets for consent (e.g. https://testdesk2.ebi.ac.uk/Ticket/Display.html?id=81661) and analysis request (e.g. https://testdesk2.ebi.ac.uk/Ticket/Display.html?id=81662)