### PR TITLE
Webuploader fixes: config files and Django3/Oracle11 incompatibility 

### DIFF
--- a/emgapianns/management/commands/import_assembly.py
+++ b/emgapianns/management/commands/import_assembly.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
 
     def get_ena_db_assembly(self, accession):
         logger.info("Fetching assembly {} from ena oracle DB".format(accession))
-        return ena_models.Assembly.objects.using(self.ena_db).filter(assembly_id=accession).first()
+        return ena_models.Assembly.objects.using(self.ena_db).get(assembly_id=accession)
 
     def create_or_update_assembly(self, ena_assembly):
         accession = ena_assembly.assembly_id

--- a/emgapianns/management/commands/import_run.py
+++ b/emgapianns/management/commands/import_run.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
 
     def get_ena_db_run(self, accession):
         logger.info('Fetching run {} from ena oracle DB'.format(accession))
-        return ena_models.Run.objects.using(self.ena_db).filter(run_id=accession).first()
+        return ena_models.Run.objects.using(self.ena_db).filter(run_id=accession)[0]
 
     def create_or_update_run(self, db_data, api_data):
         accession = api_data['run_accession']

--- a/emgapianns/management/commands/import_sample.py
+++ b/emgapianns/management/commands/import_sample.py
@@ -161,8 +161,8 @@ class Command(BaseCommand):
 
     def get_ena_db_sample(self, accession):
         logger.info('Fetching sample {} from ena oracle DB'.format(accession))
-        query = Q(sample_id=accession) | Q(biosample_id=accession)
-        return ena_models.Sample.objects.using(self.ena_db).filter(query).first()
+        # query = Q(sample_id=accession) | Q(biosample_id=accession)
+        return ena_models.Sample.objects.using(self.ena_db).filter(sample_id=accession, biosample_id=accession, combine_operator='OR')[0]
 
     def get_variable(self, name):
         try:
@@ -215,8 +215,7 @@ class Command(BaseCommand):
     def get_backlog_lineage(sample_accession):
         try:
             run = backlog_models.Run.objects.using('backlog_prod') \
-                .filter(sample_primary_accession=sample_accession) \
-                .first()
+                .filter(sample_primary_accession=sample_accession)[0]
             return run.biome.lineage
         except AttributeError:
             logging.error('Could not retrieve backlog biome for sample {}, '

--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -64,13 +64,13 @@ class StudyImporter:
         db_result, api_result = None, None
         try:
             db_result = ena_models.RunStudy.objects.using(database).raw(f"""
-                select * from {ena_models.RunStudy.Meta.db_table}
+                select * from {ena_models.RunStudy._meta.db_table}
                 where STUDY_ID=%s or PROJECT_ID=%s
                 """, [study_accession, study_accession])
         except RunStudy.DoesNotExist:
             try:
                 db_result = ena_models.AssemblyStudy.objects.using(database).raw(f"""
-                    select * from {ena_models.AssemblyStudy.Meta.db_table}
+                    select * from {ena_models.AssemblyStudy._meta.db_table}
                     where STUDY_ID=%s or PROJECT_ID=%s
                 """, [study_accession, study_accession])
             except AssemblyStudy.DoesNotExist:

--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -63,12 +63,16 @@ class StudyImporter:
         """
         db_result, api_result = None, None
         try:
-            db_result = ena_models.RunStudy.objects.using(database).get(
-                Q(study_id=study_accession) | Q(project_id=study_accession))
+            db_result = ena_models.RunStudy.objects.using(database).raw(f"""
+                select * from {ena_models.RunStudy.Meta.db_table}
+                where STUDY_ID=%s or PROJECT_ID=%s
+                """, [study_accession, study_accession])
         except RunStudy.DoesNotExist:
             try:
-                db_result = ena_models.AssemblyStudy.objects.using(database).get(
-                    Q(study_id=study_accession) | Q(project_id=study_accession))
+                db_result = ena_models.AssemblyStudy.objects.using(database).raw(f"""
+                    select * from {ena_models.AssemblyStudy.Meta.db_table}
+                    where STUDY_ID=%s or PROJECT_ID=%s
+                """, [study_accession, study_accession])
             except AssemblyStudy.DoesNotExist:
                 logging.warning(
                     "Could not find study {0} in the ENA database (ERAPRO). Calling ENA Portal API "

--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -62,7 +62,7 @@ class StudyImporter:
         """
         db_result, api_result = None, None
         try:
-            db_result = ena_models.RunStudy.objects.using(database).filter(study_id=study_accession, project_id=study_accession, combine_operator='OR')
+            db_result = ena_models.RunStudy.objects.using(database).get(study_id=study_accession, project_id=study_accession, combine_operator='OR')
         except RunStudy.DoesNotExist:
             try:
                 db_result = ena_models.AssemblyStudy.objects.using(database).get(study_id=study_accession, project_id=study_accession, combine_operator='OR')

--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -66,14 +66,14 @@ class StudyImporter:
             db_result = ena_models.RunStudy.objects.using(database).raw(f"""
                 select * from {ena_models.RunStudy._meta.db_table}
                 where STUDY_ID=%s or PROJECT_ID=%s
-                """, [study_accession, study_accession])
-        except RunStudy.DoesNotExist:
+                """, [study_accession, study_accession])[0]
+        except (RunStudy.DoesNotExist, IndexError):
             try:
                 db_result = ena_models.AssemblyStudy.objects.using(database).raw(f"""
                     select * from {ena_models.AssemblyStudy._meta.db_table}
                     where STUDY_ID=%s or PROJECT_ID=%s
-                """, [study_accession, study_accession])
-            except AssemblyStudy.DoesNotExist:
+                """, [study_accession, study_accession])[0]
+            except (AssemblyStudy.DoesNotExist, IndexError):
                 logging.warning(
                     "Could not find study {0} in the ENA database (ERAPRO). Calling ENA Portal API "
                     "now to retrieve study metadata.".format(study_accession))

--- a/emgapianns/management/lib/utils.py
+++ b/emgapianns/management/lib/utils.py
@@ -385,7 +385,7 @@ def get_result_dir(result_dir, substring="results/"):
 
 def read_config(config_path, db):
     EMG_CONF = yamjam(config_path)
-    backlog_config = EMG_CONF.get('backlog', {}).get(db)
+    backlog_config = EMG_CONF.get('backlog', {}).get('databases', {}).get(db)
     if not backlog_config:
         raise Exception(f"Could not find Backlog Config for db={db} in {config_path}")
     backlog_config['raise_on_warnings'] = True

--- a/emgapianns/management/lib/utils.py
+++ b/emgapianns/management/lib/utils.py
@@ -388,8 +388,12 @@ def read_config(config_path, db):
     backlog_config = EMG_CONF.get('backlog', {}).get('databases', {}).get(db)
     if not backlog_config:
         raise Exception(f"Could not find Backlog Config for db={db} in {config_path}")
-    backlog_config['raise_on_warnings'] = True
-    backlog_config['autocommit'] = True
-    backlog_config['port'] = int(backlog_config["port"])
-    return backlog_config
+    return {
+        'raise_on_warnings': True,
+        'autocommit': True,
+        'port': backlog_config['PORT'],
+        'host': backlog_config['HOST'],
+        'user': backlog_config['USER'],
+        'password': backlog_config['PASSWORD'],
+    }
 

--- a/emgapianns/management/lib/utils.py
+++ b/emgapianns/management/lib/utils.py
@@ -19,7 +19,8 @@ import os
 import re
 import sys
 import unicodedata
-import json
+
+from YamJam import yamjam
 
 from emgapi import models as emg_models
 from emgapianns.management.lib.downloadable_files import ChunkedDownloadFiles, UnchunkedDownloadFile
@@ -373,12 +374,22 @@ def get_result_dir(result_dir, substring="results/"):
     return result_dir[pos + len(substring):]
 
 
+# def read_config(config_path, db):
+#     with open(config_path, 'r') as json_config:
+#         whole_config = json.load(json_config)
+#         config = whole_config[db]
+#         config["raise_on_warnings"] = True
+#         config["autocommit"] = True
+#         config["port"] = int(config["port"])
+#     return config
+
 def read_config(config_path, db):
-    with open(config_path, 'r') as json_config:
-        whole_config = json.load(json_config)
-        config = whole_config[db]
-        config["raise_on_warnings"] = True
-        config["autocommit"] = True
-        config["port"] = int(config["port"])
-    return config
+    EMG_CONF = yamjam(config_path)
+    backlog_config = EMG_CONF.get('backlog', {}).get(db)
+    if not backlog_config:
+        raise Exception(f"Could not find Backlog Config for db={db} in {config_path}")
+    backlog_config['raise_on_warnings'] = True
+    backlog_config['autocommit'] = True
+    backlog_config['port'] = int(backlog_config["port"])
+    return backlog_config
 

--- a/emgena/models.py
+++ b/emgena/models.py
@@ -27,7 +27,7 @@
 from __future__ import unicode_literals
 
 from datetime import date
-from django.db import models
+from django.db import models, NotSupportedError
 
 
 class Submitter(models.Model):
@@ -114,6 +114,58 @@ class AssemblyMapping(models.Model):
         return self.accession
 
 
+class Oracle11Manager(models.QuerySet):
+    def filter(self, *args, **kwargs):
+        """
+        Return a RawQuerySet which shares some of the functionality of a QuerySet.
+        Uses Raw SQL to give compatibility with Oracle DB 11 (e.g. ENA ERAPRO).
+
+        Example:
+        Model.filter(my_id=1, my_name='thor', combiner_operator='OR')
+        """
+        combiner = kwargs.pop('combine_operator', 'AND')
+        if len(kwargs) < 1:
+            raise NotSupportedError(
+                'Calling .get(...) without kwargs is not supported for Oracle11 compatibility.'
+            )
+        if len(args) > 0:
+            raise NotSupportedError(
+                'Calling .filter(...) with args is not supported for Oracle11 compatibility.'
+            )
+        query = f'SELECT * FROM {self.model._meta.db_table}'
+        first = True
+        for where_k, where_v in kwargs.items():
+            where_clause = f"{where_k}='{where_v}'" if type(where_v) is str else f"{where_k}={where_v}"
+            if first:
+                query += f" WHERE {where_clause}"
+            else:
+                query += f" {combiner} {where_clause}"
+
+        return self.raw(query)
+
+    def get(self, *args, **kwargs):
+        """
+        Perform the query and return a single object matching the given
+        keyword arguments (else raise an error).
+        Simplified to generate SQL compatible with Oracle11 (as used by ENA ERAPRO db).
+
+        Example:
+        Model.get(my_id=1, my_name='thor', combiner_operator='OR')
+        (default is to AND together the kwargs)
+        """
+        rqs = self.filter(*args, **kwargs)
+        num = len(rqs)
+        if num == 1:
+            return rqs[0]
+        if not num:
+            raise self.model.DoesNotExist(
+                f"{self.model._meta.object_name} matching query does not exist."
+            )
+        raise self.model.MultipleObjectsReturned(
+            f'get() returned more than one {self.model._meta.object_name} -- it returned {num}!'
+        )
+
+
 class Study(models.Model):
     study_id = models.CharField(db_column='STUDY_ID', primary_key=True, max_length=15)
     project_id = models.CharField(db_column='PROJECT_ID', max_length=15)
@@ -126,6 +178,8 @@ class Study(models.Model):
     study_description = models.TextField(db_column='STUDY_DESCRIPTION')
     submission_account_id = models.CharField(db_column='SUBMISSION_ACCOUNT_ID', max_length=15)
     pubmed_id = models.TextField(db_column='PUBMED_ID', max_length=4000)
+
+    objects = Oracle11Manager.as_manager()
 
     @property
     def get_study_id(self):
@@ -156,6 +210,8 @@ class Project(models.Model):
     project_id = models.CharField(db_column='PROJECT_ID', primary_key=True, max_length=15)
     center_name = models.TextField(db_column='CENTER_NAME', max_length=500)
 
+    objects = Oracle11Manager.as_manager()
+
     class Meta:
         managed = False
         app_label = 'emgena'
@@ -175,6 +231,8 @@ class Sample(models.Model):
     title = models.CharField(db_column='SAMPLE_TITLE', max_length=200)
     alias = models.CharField(db_column='SAMPLE_ALIAS', max_length=200)
     checklist = models.CharField(db_column='CHECKLIST_ID', max_length=200)
+
+    objects = Oracle11Manager.as_manager()
 
     @property
     def is_public(self):
@@ -196,6 +254,8 @@ class Run(models.Model):
     last_updated = models.DateField(db_column='LAST_UPDATED')
     submission_account_id = models.CharField(db_column='SUBMISSION_ACCOUNT_ID', max_length=15)
 
+    objects = Oracle11Manager.as_manager()
+
     class Meta:
         managed = False
         app_label = 'emgena'
@@ -214,6 +274,8 @@ class Analysis(models.Model):
     secondary_study_accession = models.CharField(db_column='STUDY_ID', max_length=15)
     unique_alias = models.CharField(db_column='UNIQUE_ALIAS', max_length=100)
     submission_account_id = models.CharField(db_column='SUBMISSION_ACCOUNT_ID', max_length=15)
+
+    objects = Oracle11Manager.as_manager()
 
     class Meta:
         managed = False
@@ -237,6 +299,8 @@ class Assembly(models.Model):
     coverage = models.IntegerField(db_column='COVERAGE')
     min_gap_length = models.IntegerField(db_column='MIN_GAP_LENGTH', null=True, blank=True)
     contig_accession_range = models.CharField(db_column='CONTIG_ACC_RANGE', max_length=50)
+
+    objects = Oracle11Manager.as_manager()
 
     class Meta:
         managed = False

--- a/emgena/models.py
+++ b/emgena/models.py
@@ -138,6 +138,7 @@ class Oracle11Manager(models.QuerySet):
             where_clause = f"{where_k}='{where_v}'" if type(where_v) is str else f"{where_k}={where_v}"
             if first:
                 query += f" WHERE {where_clause}"
+                first = False
             else:
                 query += f" {combiner} {where_clause}"
 


### PR DESCRIPTION
This PR:
- (hopefully) resolves issues with missing/unexpected formatting in config files, that have probably existed since https://github.com/EBI-Metagenomics/emgapi/pull/199
- adds a minimal level of compatibility with the ENA database, which runs on Oracle11g. Oracle11g support was dropped by Django after version 1.11. 
    - This means the ENA connection has not worked since https://github.com/EBI-Metagenomics/emgapi/pull/204
    - Django 1.11LTS end-of-life was last year. Oracle11g end-of-life was December, so is now unsupported.
    - We cannot switch entirely to the ENA API because a few fields we need are not there currently, but when they are we should stop querying the ENA databases directly from these webuploader commands.
    - the compatibility is based on overriding `.filter()` and `.get()` for ENA models, using a `queryset.raw('...sql...')` to send SQL that is compatible. Django creates incompatible SQL. It is quite a fragile hack so the sooner we switch to the API the better (e.g. because a Django `RawQuerySet` doesn't have a `.first()` method, I didn't add chaining support, and you can't use a `Q` filter with this... etc etc.)