### PR TITLE
Stop ASCII encoding study names/abstracts, since webuploader is now py3

### DIFF
--- a/emgapianns/management/lib/utils.py
+++ b/emgapianns/management/lib/utils.py
@@ -190,7 +190,7 @@ def get_pipeline_version(rootpath):
 
 
 def sanitise_string(s):
-    return unicodedata.normalize('NFKD', s).encode('ascii', 'ignore')
+    return unicodedata.normalize('NFKD', s)
 
 
 def read_chunkfile(filename):


### PR DESCRIPTION
Previously Study names/descriptions were being unicode normalised, and then encoded to ASCII. In Python3, this generates a `b''` string, which Django then encodes literally (i.e. `b'the name of study'` is the database value / what is rendered in Views). Since Python 3 has default unicode strings, we shouldn't need this encoding any more.