### PR TITLE
Feature/cobs genome search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
 
     - name: 🔧 - Install Dependencies
       run: |
-        pip install -U git+git://github.com/EBI-Metagenomics/emg-backlog-schema.git
-        pip install -U git+git://github.com/EBI-Metagenomics/ena-api-handler.git
+        pip install -U git+https://github.com/EBI-Metagenomics/emg-backlog-schema.git
+        pip install -U git+https://github.com/EBI-Metagenomics/ena-api-handler.git
         pip install -U -r requirements.txt
         pip install -U -r requirements-test.txt
         pip install "flake8==3.4" "pycodestyle==2.3.1" pep8-naming

--- a/emgapi/models.py
+++ b/emgapi/models.py
@@ -1701,6 +1701,10 @@ class Genome(models.Model):
             name = None
         return name
 
+    @staticmethod
+    def id_from_accession(accession):
+        return int(accession[4:])
+
     class Meta:
         db_table = 'GENOME'
 

--- a/emgapi/urls.py
+++ b/emgapi/urls.py
@@ -322,7 +322,7 @@ router.register(
     basename='genomes'
 )
 
-# Proxy BIGSI search requests to alternative backend
+# Proxy Genome Search requests to microservice backend
 router.register(
     r'genome-search',
     views.GenomeFragmentSearchViewSet,

--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -1324,10 +1324,6 @@ class GenomeFragmentSearchViewSet(viewsets.GenericViewSet):
     permission_classes = [AllowAny]
     parser_classes = [FormParser, MultiPartParser]
 
-    @staticmethod
-    def genome_id_from_accession(accession):
-        return int(accession[4:])
-
     def get_queryset(self):
         return None
 
@@ -1349,7 +1345,7 @@ class GenomeFragmentSearchViewSet(viewsets.GenericViewSet):
 
         results = response.get('results', [])
         logging.info(f'Got {len(results)} search results')
-        mgyg_matches = [self.genome_id_from_accession(result.get('genome')) for result in results]
+        mgyg_matches = [emg_models.Genome.id_from_accession(result.get('genome')) for result in results]
         genomes = emg_models.Genome.objects.filter(genome_id__in=mgyg_matches).all()
 
         matches = {

--- a/emgcli/settings.py
+++ b/emgcli/settings.py
@@ -179,7 +179,7 @@ except KeyError:
 try:
     GENOME_SEARCH_PROXY = EMG_CONF['emg']['genome_fragment_search_url']
 except KeyError:
-    GENOME_SEARCH_PROXY = 'https://bigsi-genome-search-01.mgnify.org/search'
+    GENOME_SEARCH_PROXY = 'https://cobs-genome-search-01.mgnify.org/search'
 
 # Admin panel
 try:


### PR DESCRIPTION
This PR:
- switches the Genome Search (by fragment) feature over to using COBS as a backend.
- augments the Genome Search results (which are now just MGYG IDs and match scores) with the Genome attributes from the database, so that clients can display tables of the results.