### PR TITLE
Optimise upload of contigs/annotations into mongodb

### DIFF
--- a/emgapianns/management/commands/import_contigs.py
+++ b/emgapianns/management/commands/import_contigs.py
@@ -211,38 +211,67 @@ class Command(EMGBaseCommand):
                 if 'kegg' in annotations:
                     kegg_feature_count = Counter(annotations['kegg'])
                     contig.has_kegg = bool(kegg_feature_count)
-                    contig.keggs = map(lambda f: m_models.AnalysisJobKeggOrthologAnnotation(ko=f, count=kegg_feature_count[f]), kegg_feature_count)
+                    contig.keggs = map(
+                        lambda f: m_models.AnalysisJobKeggOrthologAnnotation(
+                            ko=f,
+                            count=kegg_feature_count[f]),
+                        kegg_feature_count)
 
                 if 'cog' in annotations:
                     cog_feature_count = Counter(annotations['cog'])
                     contig.has_cog = bool(cog_feature_count)
-                    contig.cogs = map(lambda f: m_models.AnalysisJobCOGAnnotation(cog=f, count=cog_feature_count[f]), cog_feature_count)
+                    contig.cogs = map(
+                        lambda f: m_models.AnalysisJobCOGAnnotation(
+                            cog=f,
+                            count=cog_feature_count[f]),
+                        cog_feature_count)
 
                 if 'pfam' in annotations:
                     pfam_feature_count = Counter(annotations['pfam'])
                     contig.has_pfam = bool(pfam_feature_count)
-                    contig.pfams = list(map(lambda f: m_models.AnalysisJobPfamAnnotation(pfam_entry=f, count=pfam_feature_count[f]),
-                                      pfam_feature_count))
+                    contig.pfams = map(
+                        lambda f: m_models.AnalysisJobPfamAnnotation(
+                            pfam_entry=f,
+                            count=pfam_feature_count[f]),
+                        pfam_feature_count)
 
                 if 'interpro' in annotations:
                     interpro_feature_count = Counter(annotations['interpro'])
                     contig.has_interpro = bool(interpro_feature_count)
-                    contig.interpros = map(lambda f: m_models.AnalysisJobInterproIdentifierAnnotation(interpro_identifier=f, count=interpro_feature_count[f]), interpro_feature_count)
+                    contig.interpros = map(
+                        lambda f: m_models.AnalysisJobInterproIdentifierAnnotation(
+                            interpro_identifier=f,
+                            count=interpro_feature_count[f]),
+                        interpro_feature_count)
 
                 if 'go' in annotations:
                     go_feature_count = Counter(annotations['go'])
                     contig.has_go = bool(go_feature_count)
-                    contig.gos = map(lambda f: m_models.AnalysisJobGoTermAnnotation(go_term=f, count=go_feature_count[f]), go_feature_count)
+                    contig.gos = map(
+                        lambda f: m_models.AnalysisJobGoTermAnnotation(
+                            go_term=f,
+                            count=go_feature_count[f]),
+                        go_feature_count)
 
                 if 'antismash' in annotations:
                     antismash_feature_count = Counter(annotations['antismash'])
                     contig.has_antismash = bool(antismash_feature_count)
-                    contig.as_geneclusters = map(lambda f: m_models.AnalysisJobAntiSmashGCAnnotation(gene_cluster=f, count=antismash_feature_count[f]), antismash_feature_count)
+                    contig.as_geneclusters = map(
+                        lambda f: m_models.AnalysisJobAntiSmashGCAnnotation(
+                            gene_cluster=f,
+                            count=antismash_feature_count[f]),
+                        antismash_feature_count)
 
                 if 'keggmodules' in annotations:
                     kegg_modules = annotations['keggmodules'].items()
                     contig.has_antismash = bool(kegg_modules)
-                    contig.kegg_modules = map(lambda km: m_models.AnalysisJobKeggModuleAnnotation(module=km[0], completeness=km[1][0], matching_kos=km[1][1] or [], missing_kos=km[1][2] or []), kegg_modules)
+                    contig.kegg_modules = map(
+                        lambda km: m_models.AnalysisJobKeggModuleAnnotation(
+                            module=km[0],
+                            completeness=km[1][0],
+                            matching_kos=km[1][1] or [],
+                            missing_kos=km[1][2] or []),
+                        kegg_modules)
 
                 new_contigs.append(contig)
                 if len(new_contigs) % batch_size == 0:

--- a/emgapianns/management/commands/import_contigs.py
+++ b/emgapianns/management/commands/import_contigs.py
@@ -223,9 +223,6 @@ class Command(EMGBaseCommand):
                     contig.has_pfam = bool(pfam_feature_count)
                     contig.pfams = list(map(lambda f: m_models.AnalysisJobPfamAnnotation(pfam_entry=f, count=pfam_feature_count[f]),
                                       pfam_feature_count))
-                    if contig.contig_id == 'ERZ8153470.29114-NODE-29114-length-500-cov-0.826966':
-                        logger.warning(contig.pfams)
-                        logger.warning(pfam_feature_count)
 
                 if 'interpro' in annotations:
                     interpro_feature_count = Counter(annotations['interpro'])

--- a/emgapianns/management/commands/import_contigs.py
+++ b/emgapianns/management/commands/import_contigs.py
@@ -17,6 +17,7 @@ import logging
 from collections import Counter
 import re
 import gzip
+from itertools import islice
 
 from emgapi.utils import assembly_contig_coverage
 from emgapianns import models as m_models
@@ -27,15 +28,15 @@ logger = logging.getLogger(__name__)
 
 
 class Command(EMGBaseCommand):
-    help = 'Imports an assembly contigs and the annotations into Mongo'
+    help = "Imports an assembly contigs and the annotations into Mongo"
 
     obj_list = list()
     rootpath = None
     result_dir = None
-    PATHWAY_SUB_DIR = 'pathways-systems'
+    PATHWAY_SUB_DIR = "pathways-systems"
 
     @classmethod
-    def _split(cls, string, sep=','):
+    def _split(cls, string, sep=","):
         """String split modification, will not return [''] for empty strings
         it will return []
         """
@@ -45,136 +46,280 @@ class Command(EMGBaseCommand):
 
     def add_arguments(self, parser):
         super().add_arguments(parser)
-        parser.add_argument('--batch-size', action='store', type=int, default=10000,
-                            help='Mongo DB insert batch size.')
-        parser.add_argument('--faix', action='store', type=str,
-                            help='Fasta index file.', required=False)
-        parser.add_argument('--gff', action='store', type=str,
-                            help='GFF bgzip with the contigs annotations.', required=False)
-        parser.add_argument('--antismash', action='store', type=str,
-                            help='antiSMASH GFF bgzip.', required=False)
-        parser.add_argument('--kegg-modules', action='store', type=str,
-                            help='KEGG Modules summary file.', required=False)
-        parser.add_argument('--min-length', action='store', type=int, default=500,
-                            help='Only import contigs longer that this value.', required=False)
+        parser.add_argument(
+            "--batch-size",
+            action="store",
+            type=int,
+            default=10000,
+            help="Mongo DB insert batch size.",
+        )
+        parser.add_argument(
+            "--faix", action="store", type=str, help="Fasta index file.", required=False
+        )
+        parser.add_argument(
+            "--gff",
+            action="store",
+            type=str,
+            help="GFF bgzip with the contigs annotations.",
+            required=False,
+        )
+        parser.add_argument(
+            "--antismash",
+            action="store",
+            type=str,
+            help="antiSMASH GFF bgzip.",
+            required=False,
+        )
+        parser.add_argument(
+            "--kegg-modules",
+            action="store",
+            type=str,
+            help="KEGG Modules summary file.",
+            required=False,
+        )
+        parser.add_argument(
+            "--min-length",
+            action="store",
+            type=int,
+            default=500,
+            help="Only import contigs longer that this value.",
+            required=False,
+        )
 
     def populate_from_accession(self, options):
-        logger.info('Found {}'.format(len(self.obj_list)))
+        logger.info("Found {}".format(len(self.obj_list)))
         for analysis_job in self.obj_list:
             self.load_contigs(analysis_job, options)
 
     def load_gff(self, gff, annotations_dict):
-        """Load the GFF eggNOG data on the cache
-        """
+        """Load the GFF eggNOG data on the cache"""
         if not os.path.exists(gff):
-            logger.error('GFF file does not exist. Path:' + gff)
-            raise ValueError('GFF file does not exist')
+            logger.error("GFF file does not exist. Path:" + gff)
+            raise ValueError("GFF file does not exist")
 
-        with gzip.open(gff, 'rt') as gff_file:
-            logger.info('Parsing annotations from: {}'.format(gff))
+        with gzip.open(gff, "rt") as gff_file:
+            logger.info("Parsing annotations from: {}".format(gff))
             for line in gff_file:
-                if line.startswith('#'):
+                if line.startswith("#"):
                     continue
-                contig_id, *_, atts = line.split('\t')
+                contig_id, *_, atts = line.split("\t")
                 if contig_id not in annotations_dict:
                     annotations_dict[contig_id] = {
-                        'kegg': [],
-                        'cog': [],
-                        'pfam': [],
-                        'interpro': [],
-                        'go': []
+                        "kegg": [],
+                        "cog": [],
+                        "pfam": [],
+                        "interpro": [],
+                        "go": [],
                     }
-                for category in atts.split(';'):
-                    for possible_cat in ['kegg', 'cog', 'pfam', 'interpro', 'go']:
-                        if category.startswith(possible_cat + '='):
-                            values = Command._split(category.replace(possible_cat + '=', ''))
+                for category in atts.split(";"):
+                    for possible_cat in ["kegg", "cog", "pfam", "interpro", "go"]:
+                        if category.startswith(possible_cat + "="):
+                            values = Command._split(
+                                category.replace(possible_cat + "=", "")
+                            )
                             annotations_dict[contig_id][possible_cat].extend(values)
 
     def load_antismash(self, antismash, annotations_dict):
-        """Load antiSMASH file data on the cache
-        """
+        """Load antiSMASH file data on the cache"""
         if not os.path.exists(antismash):
-            logger.warning('antiSMASH file does not exist. SKIPPING!')
+            logger.warning("antiSMASH file does not exist. SKIPPING!")
             return
 
-        logger.info('Loading antiSMASH')
-        with gzip.open(antismash, 'rt') as as_file:
+        logger.info("Loading antiSMASH")
+        with gzip.open(antismash, "rt") as as_file:
             for line in as_file:
-                if line.startswith('#'):
+                if line.startswith("#"):
                     continue
-                contig, *_, atts = line.split('\t')
-                contig_id = contig.replace(' ', '-')
-                contig_ann = annotations_dict.setdefault(contig_id, {'antismash': []})
-                for at in atts.split(';'):
-                    if 'as_gene_clusters' not in at:
+                contig, *_, atts = line.split("\t")
+                contig_id = contig.replace(" ", "-")
+                contig_ann = annotations_dict.setdefault(contig_id, {"antismash": []})
+                for at in atts.split(";"):
+                    if "as_gene_clusters" not in at:
                         continue
-                    for at_cluster in at.split(','):
-                        cluster = at_cluster.replace('as_gene_clusters=', '').replace('\n', '')
-                        contig_ann.setdefault('antismash', []).append(cluster)
-        logger.info('Loaded antiSMASH')
+                    for at_cluster in at.split(","):
+                        cluster = at_cluster.replace("as_gene_clusters=", "").replace(
+                            "\n", ""
+                        )
+                        contig_ann.setdefault("antismash", []).append(cluster)
+        logger.info("Loaded antiSMASH")
 
     def load_kegg_modules(self, kegg_modules, annotations_dict):
-        """Load KEGG Modules and paths
-        """
+        """Load KEGG Modules and paths"""
         if not os.path.exists(kegg_modules):
-            logger.warning('KEGG Modules files does not exist. SKIPPING!')
+            logger.warning("KEGG Modules files does not exist. SKIPPING!")
             return
         # KEGG Modules per contig is loaded from
         # the summary file
-        logger.info('Loading the KEGG Modules')
+        logger.info("Loading the KEGG Modules")
         km_dict = {}
-        with open(kegg_modules, 'rt') as km_file:
+        with open(kegg_modules, "rt") as km_file:
             next(km_file)
             for line in km_file:
-                contig, module, completeness, _, _, matching, missing = line.split('\t')
+                contig, module, completeness, _, _, matching, missing = line.split("\t")
                 # re-format removing the faa prefix
                 # ERZ782910.4199-NODE_4199_length_728_cov_2.072808_1 to
                 # ERZ782910.4199-NODE_4199_length_728_cov_2.072808
-                contig = re.sub(r'_\d+$', '', contig)
+                contig = re.sub(r"_\d+$", "", contig)
                 # store the modules per contig, one contig could
                 # have the same module several times
-                el = [float(completeness), Command._split(matching), Command._split(missing)]
-                km_dict.setdefault(contig, {}) \
-                       .setdefault(module, {}) \
-                       .append(el)
+                el = [
+                    float(completeness),
+                    Command._split(matching),
+                    Command._split(missing),
+                ]
+                km_dict.setdefault(contig, {}).setdefault(module, {}).append(el)
         # extend the annotations
         for contig, modules in km_dict.items():
             if contig not in annotations_dict:
                 annotations_dict[contig] = {}
             annotations_dict[contig].update(KEGGModules=modules)
 
-    def load_contigs(self, analysis_job, options):
-        """Load the contigs in Mongo
-        """
-        logger.info('CLI {}'.format(options))
+    def create_contig(self, fasta_line, annotations_dict, min_length, analysis_job):
+        contig_id, length, *_ = fasta_line.split("\t")
+        annotations = annotations_dict.get(contig_id, {})
+        if min_length > int(length) or not annotations:
+            return
 
-        rootpath = options.get('rootpath', None)
+        contig = m_models.AnalysisJobContig(
+            contig_id=contig_id.strip(),
+            length=length,
+            coverage=assembly_contig_coverage(contig_id),
+            analysis_id=str(analysis_job.job_id),
+            accession=analysis_job.accession,
+            job_id=analysis_job.job_id,
+            pipeline_version=analysis_job.pipeline.release_version,
+        )
+
+        if "kegg" in annotations:
+            kegg_feature_count = Counter(annotations["kegg"])
+            contig.has_kegg = bool(kegg_feature_count)
+            contig.keggs = list(
+                map(
+                    lambda f: m_models.AnalysisJobKeggOrthologAnnotation(
+                        ko=f, count=kegg_feature_count[f]
+                    ),
+                    kegg_feature_count,
+                )
+            )
+
+        if "cog" in annotations:
+            cog_feature_count = Counter(annotations["cog"])
+            contig.has_cog = bool(cog_feature_count)
+            contig.cogs = list(
+                map(
+                    lambda f: m_models.AnalysisJobCOGAnnotation(
+                        cog=f, count=cog_feature_count[f]
+                    ),
+                    cog_feature_count,
+                )
+            )
+
+        if "pfam" in annotations:
+            pfam_feature_count = Counter(annotations["pfam"])
+            contig.has_pfam = bool(pfam_feature_count)
+            contig.pfams = list(
+                map(
+                    lambda f: m_models.AnalysisJobPfamAnnotation(
+                        pfam_entry=f, count=pfam_feature_count[f]
+                    ),
+                    pfam_feature_count,
+                )
+            )
+
+        if "interpro" in annotations:
+            interpro_feature_count = Counter(annotations["interpro"])
+            contig.has_interpro = bool(interpro_feature_count)
+            contig.interpros = list(
+                map(
+                    lambda f: m_models.AnalysisJobInterproIdentifierAnnotation(
+                        interpro_identifier=f, count=interpro_feature_count[f]
+                    ),
+                    interpro_feature_count,
+                )
+            )
+
+        if "go" in annotations:
+            go_feature_count = Counter(annotations["go"])
+            contig.has_go = bool(go_feature_count)
+            contig.gos = list(
+                map(
+                    lambda f: m_models.AnalysisJobGoTermAnnotation(
+                        go_term=f, count=go_feature_count[f]
+                    ),
+                    go_feature_count,
+                )
+            )
+
+        if "antismash" in annotations:
+            antismash_feature_count = Counter(annotations["antismash"])
+            contig.has_antismash = bool(antismash_feature_count)
+            contig.as_geneclusters = list(
+                map(
+                    lambda f: m_models.AnalysisJobAntiSmashGCAnnotation(
+                        gene_cluster=f, count=antismash_feature_count[f]
+                    ),
+                    antismash_feature_count,
+                )
+            )
+
+        if "keggmodules" in annotations:
+            kegg_modules = annotations["keggmodules"].items()
+            contig.has_antismash = bool(kegg_modules)
+            contig.kegg_modules = list(
+                map(
+                    lambda km: m_models.AnalysisJobKeggModuleAnnotation(
+                        module=km[0],
+                        completeness=km[1][0],
+                        matching_kos=km[1][1] or [],
+                        missing_kos=km[1][2] or [],
+                    ),
+                    kegg_modules,
+                )
+            )
+        return contig
+
+    def load_contigs(self, analysis_job, options):
+        """Load the contigs in Mongo"""
+        logger.info("CLI {}".format(options))
+
+        rootpath = options.get("rootpath", None)
         # no_antismash file detection
-        if os.path.isfile(os.path.join(rootpath, analysis_job.result_directory, 'no_antismash')):
-            logger.warning('No antismash results, SKIPPING!')
+        if os.path.isfile(
+            os.path.join(rootpath, analysis_job.result_directory, "no_antismash")
+        ):
+            logger.warning("No antismash results, SKIPPING!")
             return
 
         result_folder = os.path.join(rootpath, analysis_job.result_directory)
         result_file_prefix = analysis_job.input_file_name
         # ERZ782882_FASTA.fasta.bgz.fai
-        default_faix_file_path = os.path.join(result_folder,
-                                              "{}.{}".format(result_file_prefix, "fasta.bgz.fai"))
-        faix = options['faix'] or default_faix_file_path
+        default_faix_file_path = os.path.join(
+            result_folder, "{}.{}".format(result_file_prefix, "fasta.bgz.fai")
+        )
+        faix = options["faix"] or default_faix_file_path
         # functional-annotation/ERZ782882_FASTA.contigs.annotations.gff.gz
-        default_gff_file_path = os.path.join(result_folder, "functional-annotation",
-                                             "{}.{}".format(result_file_prefix, "annotations.gff.bgz"))
-        gff = options['gff'] or default_gff_file_path
+        default_gff_file_path = os.path.join(
+            result_folder,
+            "functional-annotation",
+            "{}.{}".format(result_file_prefix, "annotations.gff.bgz"),
+        )
+        gff = options["gff"] or default_gff_file_path
         # TODO: calculation not implemented in pipeline yet.
         # kegg_modules = options['kegg_modules'] or root_file + '_summary.paths.kegg'
         # pathways-systems/ERZ782882_FASTA.antismash.gff.gz
-        default_antismash_file_path = os.path.join(result_folder, "pathways-systems",
-                                                   "{}.{}".format(result_file_prefix, "antismash.gff.bgz"))
-        antismash = options['antismash'] or default_antismash_file_path
+        default_antismash_file_path = os.path.join(
+            result_folder,
+            "pathways-systems",
+            "{}.{}".format(result_file_prefix, "antismash.gff.bgz"),
+        )
+        antismash = options["antismash"] or default_antismash_file_path
 
-        min_length = options['min_length']
-        batch_size = options['batch_size']
+        min_length = options["min_length"]
+        batch_size = options["batch_size"]
 
-        logger.info('Starting the contigs import process for: ' + str(analysis_job.accession))
+        logger.info(
+            "Starting the contigs import process for: " + str(analysis_job.accession)
+        )
 
         annotations_dict = {}
         self.load_gff(gff, annotations_dict)
@@ -187,97 +332,20 @@ class Command(EMGBaseCommand):
             analysis_id=str(analysis_job.job_id),
             accession=analysis_job.accession,
             job_id=analysis_job.job_id,
-            pipeline_version=analysis_job.pipeline.release_version).delete()
+            pipeline_version=analysis_job.pipeline.release_version,
+        ).delete()
 
-        with open(faix, 'r') as fasta:
-            new_contigs = []
-            for line in fasta:
-                contig_id, length, *_ = line.split('\t')
-
-                annotations = annotations_dict.get(contig_id, {})
-                if min_length > int(length) or not annotations:
-                    continue
-
-                contig = m_models.AnalysisJobContig(
-                    contig_id=contig_id.strip(),
-                    length=length,
-                    coverage=assembly_contig_coverage(contig_id),
-                    analysis_id=str(analysis_job.job_id),
-                    accession=analysis_job.accession,
-                    job_id=analysis_job.job_id,
-                    pipeline_version=analysis_job.pipeline.release_version
+        with open(faix, "r") as fasta:
+            for batch_of_lines in iter(lambda: tuple(islice(fasta, batch_size)), ()):
+                new_contigs = map(
+                    lambda line: self.create_contig(
+                        line, annotations_dict, min_length, analysis_job
+                    ),
+                    batch_of_lines,
                 )
-
-                if 'kegg' in annotations:
-                    kegg_feature_count = Counter(annotations['kegg'])
-                    contig.has_kegg = bool(kegg_feature_count)
-                    contig.keggs = map(
-                        lambda f: m_models.AnalysisJobKeggOrthologAnnotation(
-                            ko=f,
-                            count=kegg_feature_count[f]),
-                        kegg_feature_count)
-
-                if 'cog' in annotations:
-                    cog_feature_count = Counter(annotations['cog'])
-                    contig.has_cog = bool(cog_feature_count)
-                    contig.cogs = map(
-                        lambda f: m_models.AnalysisJobCOGAnnotation(
-                            cog=f,
-                            count=cog_feature_count[f]),
-                        cog_feature_count)
-
-                if 'pfam' in annotations:
-                    pfam_feature_count = Counter(annotations['pfam'])
-                    contig.has_pfam = bool(pfam_feature_count)
-                    contig.pfams = map(
-                        lambda f: m_models.AnalysisJobPfamAnnotation(
-                            pfam_entry=f,
-                            count=pfam_feature_count[f]),
-                        pfam_feature_count)
-
-                if 'interpro' in annotations:
-                    interpro_feature_count = Counter(annotations['interpro'])
-                    contig.has_interpro = bool(interpro_feature_count)
-                    contig.interpros = map(
-                        lambda f: m_models.AnalysisJobInterproIdentifierAnnotation(
-                            interpro_identifier=f,
-                            count=interpro_feature_count[f]),
-                        interpro_feature_count)
-
-                if 'go' in annotations:
-                    go_feature_count = Counter(annotations['go'])
-                    contig.has_go = bool(go_feature_count)
-                    contig.gos = map(
-                        lambda f: m_models.AnalysisJobGoTermAnnotation(
-                            go_term=f,
-                            count=go_feature_count[f]),
-                        go_feature_count)
-
-                if 'antismash' in annotations:
-                    antismash_feature_count = Counter(annotations['antismash'])
-                    contig.has_antismash = bool(antismash_feature_count)
-                    contig.as_geneclusters = map(
-                        lambda f: m_models.AnalysisJobAntiSmashGCAnnotation(
-                            gene_cluster=f,
-                            count=antismash_feature_count[f]),
-                        antismash_feature_count)
-
-                if 'keggmodules' in annotations:
-                    kegg_modules = annotations['keggmodules'].items()
-                    contig.has_antismash = bool(kegg_modules)
-                    contig.kegg_modules = map(
-                        lambda km: m_models.AnalysisJobKeggModuleAnnotation(
-                            module=km[0],
-                            completeness=km[1][0],
-                            matching_kos=km[1][1] or [],
-                            missing_kos=km[1][2] or []),
-                        kegg_modules)
-
-                new_contigs.append(contig)
-                if len(new_contigs) % batch_size == 0:
-                    m_models.AnalysisJobContig.objects.insert(new_contigs, load_bulk=False)
-                    logger.info('Creating {} new contigs'.format(len(new_contigs)))
-                    new_contigs = []
-        if len(new_contigs):
-            m_models.AnalysisJobContig.objects.insert(new_contigs, load_bulk=False)
-            logger.info('Creating {} new contigs'.format(len(new_contigs)))
+                new_contigs = list(filter(lambda c: c is not None, new_contigs))
+                if len(new_contigs):
+                    m_models.AnalysisJobContig.objects.insert(
+                        new_contigs, load_bulk=False
+                    )
+                logger.info("Creating {} new contigs".format(len(new_contigs)))

--- a/emgapianns/management/commands/import_summary.py
+++ b/emgapianns/management/commands/import_summary.py
@@ -324,7 +324,7 @@ class Command(EMGBaseCommand):
             for entity in existing_entities:
                 referenced_entities.pop(entity.id)
             if referenced_entities:
-                entity_model.objects.insert(referenced_entities)
+                entity_model.objects.insert(referenced_entities.values())
             logger.info(
                 'Created {} new entries'.format(len(referenced_entities)))
 

--- a/emgapianns/management/commands/import_summary.py
+++ b/emgapianns/management/commands/import_summary.py
@@ -300,35 +300,33 @@ class Command(EMGBaseCommand):
         analysis.pipeline_version = obj.pipeline.release_version
         analysis.job_id = obj.job_id
 
-        new_entities = []
+        referenced_entities = {}
         annotations = []
 
         # drop previous annotations
         setattr(analysis, analysis_field, [])
         analysis.save()
 
-        # next(reader)  # skip header
-
         for count, model_id, description in reader:
             count = int(count)
 
-            new_entity = None
-            try:
-                new_entity = entity_model.objects.get(accession=model_id)
-            except entity_model.DoesNotExist:
-                new_entity = entity_model(
-                    accession=model_id,
-                    description=description
-                )
-                new_entities.append(new_entity)
+            entity = entity_model(
+                accession=model_id,
+                description=description
+            )
+            referenced_entities[model_id] = entity
             new_annotation = ann_model(count=count)
-            setattr(new_annotation, ann_field, new_entity)
+            setattr(new_annotation, ann_field, entity)
             annotations.append(new_annotation)
 
-        if len(new_entities):
-            entity_model.objects.insert(new_entities)
+        if len(referenced_entities):
+            existing_entities = entity_model.objects.filter(accession__in=referenced_entities.keys())
+            for entity in existing_entities:
+                referenced_entities.pop(entity.id)
+            if referenced_entities:
+                entity_model.objects.insert(referenced_entities)
             logger.info(
-                'Created {} new entries'.format(len(new_entities)))
+                'Created {} new entries'.format(len(referenced_entities)))
 
         if len(annotations):
             setattr(analysis, analysis_field, annotations)
@@ -337,7 +335,6 @@ class Command(EMGBaseCommand):
 
         analysis.save()
         logger.info('Saved {}'.format(analysis_field))
-
 
     def load_genome_properties(self, reader,  obj):
         """Genome properties import, using the output summary from GP


### PR DESCRIPTION
This PR:
- speeds up `import_analysis`, by:
  - increase batch size of contigs written to mongo (tiny improvement)
  - avoid querying mongo to check existence of each annotation entity (e.g. an InterPro identifier document). Instead, query for all of the entities referenced by an analysis summary and batch create those missing.
  - switch from loops to maps when iterating through contig annotations.

Altering the mongodb insertion `write_concern` to `{'w': 0}` (i.e. do not await confirmation of insertion) made no difference, and is a bit risky, so that isn't included.

Combined these give around 20% speedup to `import_analysis`.