### PR TITLE
ENA sync commands - set the DB for the QS.

### DIFF
--- a/emgena/management/commands/sync_assemblies_with_ena.py
+++ b/emgena/management/commands/sync_assemblies_with_ena.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
                     offset : offset + batch_size
                 ]
             )
-            ena_assemblies_batch = ena_models.Assembly.objects.filter(
+            ena_assemblies_batch = ena_models.Assembly.objects.using("era_pro").filter(
                 gc_id__in=[
                     assembly.legacy_accession for assembly in emg_assemblies_batch
                 ]

--- a/emgena/management/commands/sync_runs_with_ena.py
+++ b/emgena/management/commands/sync_runs_with_ena.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
         while offset < runs_count:
             emg_runs_batch = emg_models.Run.objects.all()[offset : offset + batch_size]
-            ena_runs_batch = ena_models.Run.objects.filter(
+            ena_runs_batch = ena_models.Run.objects.using("era_pro").filter(
                 run_id__in=[run.accession for run in emg_runs_batch]
             )
 

--- a/emgena/management/commands/sync_samples_with_ena.py
+++ b/emgena/management/commands/sync_samples_with_ena.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                     offset : offset + batch_size
                 ]
             )
-            ena_samples_batch = ena_models.Sample.objects.filter(
+            ena_samples_batch = ena_models.Sample.objects.using("era_pro").filter(
                 sample_id__in=[sample.accession for sample in emg_samples_batch]
             )
 

--- a/emgena/management/commands/sync_studies_with_ena.py
+++ b/emgena/management/commands/sync_studies_with_ena.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             emg_studies_batch = list(
                 emg_models.Study.objects.all()[offset : offset + batch_size]
             )
-            ena_studies_batch = ena_models.Study.objects.filter(
+            ena_studies_batch = ena_models.Study.objects.using("era_pro").filter(
                 study_id__in=[study.secondary_accession for study in emg_studies_batch]
             )
             for emg_study in emg_studies_batch:
@@ -56,10 +56,10 @@ class Command(BaseCommand):
                     None,
                 )
                 if ena_study is None:
-                    logger.error(f"{study} not found in ENA.")
+                    logger.error(f"{emg_study} not found in ENA.")
                     continue
                 if ena_study.study_status is None:
-                    logger.error(f"{study} on ENA has no value on the column status.")
+                    logger.error(f"{emg_study} on ENA has no value on the column status.")
                     continue
 
                 emg_study.sync_with_ena_status(ena_study.study_status)

--- a/tests/ena/test_sync_assemblies_with_ena.py
+++ b/tests/ena/test_sync_assemblies_with_ena.py
@@ -32,7 +32,7 @@ class TestSyncENAAssemblies:
     def test_make_assemblies_private(
         self, ena_assemblies_objs_mock, ena_private_assemblies
     ):
-        ena_assemblies_objs_mock.filter.return_value = ena_private_assemblies
+        ena_assemblies_objs_mock.using("era_pro").filter.return_value = ena_private_assemblies
 
         public_assemblies = Assembly.objects.order_by("?").all()[0:5]
 
@@ -49,7 +49,7 @@ class TestSyncENAAssemblies:
 
     @patch("emgena.models.Assembly.objects")
     def test_make_assemblies_public(self, ena_assembly_objs_mock, ena_public_assemblies):
-        ena_assembly_objs_mock.filter.return_value = ena_public_assemblies
+        ena_assembly_objs_mock.using("era_pro").filter.return_value = ena_public_assemblies
 
         private_assemblies = Assembly.objects.order_by("?").all()[0:5]
 
@@ -66,7 +66,7 @@ class TestSyncENAAssemblies:
 
     @patch("emgena.models.Assembly.objects")
     def test_suppress_assemblies(self, ena_assembly_objs_mock, ena_suppressed_assemblies):
-        ena_assembly_objs_mock.filter.return_value = ena_suppressed_assemblies
+        ena_assembly_objs_mock.using("era_pro").filter.return_value = ena_suppressed_assemblies
 
         suppressed_assemblies = Assembly.objects.order_by("?").all()[0:5]
 

--- a/tests/ena/test_sync_runs_with_ena.py
+++ b/tests/ena/test_sync_runs_with_ena.py
@@ -30,7 +30,7 @@ from test_utils.emg_fixtures import *  # noqa
 class TestSyncENAStudies:
     @patch("emgena.models.Run.objects")
     def test_make_runs_private(self, ena_run_objs_mock, ena_private_runs):
-        ena_run_objs_mock.filter.return_value = ena_private_runs
+        ena_run_objs_mock.using("era_pro").filter.return_value = ena_private_runs
 
         public_runs = Run.objects.order_by("?").all()[0:5]
 
@@ -47,7 +47,7 @@ class TestSyncENAStudies:
 
     @patch("emgena.models.Run.objects")
     def test_make_runs_public(self, ena_run_objs_mock, ena_public_runs):
-        ena_run_objs_mock.filter.return_value = ena_public_runs
+        ena_run_objs_mock.using("era_pro").filter.return_value = ena_public_runs
 
         private_runs = Run.objects.order_by("?").all()[0:5]
 
@@ -64,7 +64,7 @@ class TestSyncENAStudies:
 
     @patch("emgena.models.Run.objects")
     def test_suppress_studies(self, ena_run_objs_mock, ena_suppressed_runs):
-        ena_run_objs_mock.filter.return_value = ena_suppressed_runs
+        ena_run_objs_mock.using("era_pro").filter.return_value = ena_suppressed_runs
 
         suppress_runs = Run.objects.order_by("?").all()[0:5]
 

--- a/tests/ena/test_sync_samples_with_ena.py
+++ b/tests/ena/test_sync_samples_with_ena.py
@@ -30,7 +30,7 @@ from test_utils.emg_fixtures import *  # noqa
 class TestSyncENAStudies:
     @patch("emgena.models.Sample.objects")
     def test_make_samples_private(self, ena_sample_objs_mock, ena_private_samples):
-        ena_sample_objs_mock.filter.return_value = ena_private_samples
+        ena_sample_objs_mock.using("era_pro").filter.return_value = ena_private_samples
 
         public_samples = Sample.objects.order_by("?").all()[0:5]
 
@@ -48,7 +48,7 @@ class TestSyncENAStudies:
 
     @patch("emgena.models.Sample.objects")
     def test_make_samples_public(self, ena_sample_objs_mock, ena_public_samples):
-        ena_sample_objs_mock.filter.return_value = ena_public_samples
+        ena_sample_objs_mock.using("era_pro").filter.return_value = ena_public_samples
 
         private_samples = Sample.objects.order_by("?").all()[0:5]
 
@@ -66,7 +66,7 @@ class TestSyncENAStudies:
 
     @patch("emgena.models.Sample.objects")
     def test_suppress_samples(self, ena_sample_objs_mock, ena_suppressed_samples):
-        ena_sample_objs_mock.filter.return_value = ena_suppressed_samples
+        ena_sample_objs_mock.using("era_pro").filter.return_value = ena_suppressed_samples
 
         suppressed_samples = Sample.objects.order_by("?").all()[0:5]
 

--- a/tests/ena/test_sync_studies_with_ena.py
+++ b/tests/ena/test_sync_studies_with_ena.py
@@ -30,7 +30,7 @@ from test_utils.emg_fixtures import *  # noqa
 class TestSyncENAStudies:
     @patch("emgena.models.Study.objects")
     def test_make_studies_private(self, ena_study_objs_mock, ena_private_studies):
-        ena_study_objs_mock.filter.return_value = ena_private_studies
+        ena_study_objs_mock.using("era_pro").filter.return_value = ena_private_studies
 
         all_studies = Study.objects.order_by("?").all()
         public_studies = all_studies[0:5]
@@ -51,7 +51,7 @@ class TestSyncENAStudies:
 
     @patch("emgena.models.Study.objects")
     def test_make_studies_public(self, ena_study_objs_mock, ena_public_studies):
-        ena_study_objs_mock.filter.return_value = ena_public_studies
+        ena_study_objs_mock.using("era_pro").filter.return_value = ena_public_studies
 
         all_studies = Study.objects.order_by("?").all()
         private_studies = all_studies[0:5]
@@ -72,7 +72,7 @@ class TestSyncENAStudies:
 
     @patch("emgena.models.Study.objects")
     def test_suppress_studies(self, ena_study_objs_mock, ena_suppressed_studies):
-        ena_study_objs_mock.filter.return_value = ena_suppressed_studies
+        ena_study_objs_mock.using("era_pro").filter.return_value = ena_suppressed_studies
 
         suppress_studies = Study.objects.order_by("?").all()[0:5]
 


### PR DESCRIPTION
Modifying the QS .using each time we want to use
those models is bad pattern. I didn't change that
as we want to migrate to the ENA in the short term.