### PR TITLE
RO-Crates for adding additional annotations to assemblies

### DIFF
--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -1301,7 +1301,7 @@ class GenomeCatalogueViewSet(mixins.RetrieveModelMixin,
                              emg_mixins.ListModelMixin,
                              emg_viewsets.BaseGenomeCatalogueGenericViewSet):
 
-    filter_class = emg_filters.GenomeCatalogueFilter
+    filterset_class = emg_filters.GenomeCatalogueFilter
 
     lookup_field = 'catalogue_id'
     lookup_value_regex = '[^/]+'
@@ -1352,7 +1352,7 @@ class GenomeViewSet(mixins.RetrieveModelMixin,
                     emg_mixins.ListModelMixin,
                     viewsets.GenericViewSet):
     serializer_class = emg_serializers.GenomeSerializer
-    filter_class = emg_filters.GenomeFilter
+    filterset_class = emg_filters.GenomeFilter
 
     lookup_field = 'accession'
     lookup_value_regex = '[^/]+'

--- a/emgapi/views_relations.py
+++ b/emgapi/views_relations.py
@@ -316,7 +316,7 @@ class StudyAnalysisResultViewSet(emg_mixins.ListModelMixin,
                                  viewsets.GenericViewSet):
     serializer_class = emg_serializers.AnalysisSerializer
 
-    filter_class = emg_filters.AnalysisJobFilter
+    filterset_class = emg_filters.AnalysisJobFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -430,7 +430,7 @@ class RunAnalysisViewSet(emg_mixins.ListModelMixin,
                          viewsets.GenericViewSet):
     serializer_class = emg_serializers.AnalysisSerializer
 
-    filter_class = emg_filters.AnalysisJobFilter
+    filterset_class = emg_filters.AnalysisJobFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -861,7 +861,7 @@ class BiomeTreeViewSet(mixins.ListModelMixin,
     serializer_class = emg_serializers.BiomeSerializer
     queryset = emg_models.Biome.objects.filter(depth=1)
 
-    filter_class = emg_filters.BiomeFilter
+    filterset_class = emg_filters.BiomeFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -983,7 +983,7 @@ class RunAssemblyViewSet(emg_mixins.ListModelMixin,
                          viewsets.GenericViewSet):
     serializer_class = emg_serializers.AssemblySerializer
 
-    filter_class = emg_filters.AssemblyFilter
+    filterset_class = emg_filters.AssemblyFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -1026,7 +1026,7 @@ class AssemblyAnalysisViewSet(emg_mixins.ListModelMixin,
                               viewsets.GenericViewSet):
     serializer_class = emg_serializers.AnalysisSerializer
 
-    filter_class = emg_filters.AnalysisJobFilter
+    filterset_class = emg_filters.AnalysisJobFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -1073,7 +1073,7 @@ class AssemblyRunsViewSet(emg_mixins.ListModelMixin,
 
     serializer_class = emg_serializers.RunSerializer
 
-    filter_class = emg_filters.RunFilter
+    filterset_class = emg_filters.RunFilter
 
     filter_backends = (
         DjangoFilterBackend,

--- a/emgapi/viewsets.py
+++ b/emgapi/viewsets.py
@@ -31,7 +31,7 @@ class BaseSuperStudyViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.SuperStudySerializer
 
-    filter_class = emg_filters.SuperStudyFilter
+    filterset_class = emg_filters.SuperStudyFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -57,7 +57,7 @@ class BaseStudyGenericViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.StudySerializer
 
-    filter_class = emg_filters.StudyFilter
+    filterset_class = emg_filters.StudyFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -88,7 +88,7 @@ class BaseSampleGenericViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.SampleSerializer
 
-    filter_class = emg_filters.SampleFilter
+    filterset_class = emg_filters.SampleFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -123,7 +123,7 @@ class BaseRunGenericViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.RunSerializer
 
-    filter_class = emg_filters.RunFilter
+    filterset_class = emg_filters.RunFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -151,7 +151,7 @@ class BaseAssemblyGenericViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.AssemblySerializer
 
-    filter_class = emg_filters.AssemblyFilter
+    filterset_class = emg_filters.AssemblyFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -177,7 +177,7 @@ class BaseAnalysisGenericViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.AnalysisSerializer
 
-    filter_class = emg_filters.AnalysisJobFilter
+    filterset_class = emg_filters.AnalysisJobFilter
 
     filter_backends = (
         DjangoFilterBackend,
@@ -210,7 +210,7 @@ class BasePublicationGenericViewSet(viewsets.GenericViewSet):
 
     serializer_class = emg_serializers.PublicationSerializer
 
-    filter_class = emg_filters.PublicationFilter
+    filterset_class = emg_filters.PublicationFilter
 
     filter_backends = (
         DjangoFilterBackend,

--- a/emgapianns/views.py
+++ b/emgapianns/views.py
@@ -871,7 +871,7 @@ class OrganismAnalysisRelationshipViewSet(m_viewsets.ListReadOnlyModelViewSet):
 
     serializer_class = emg_serializers.AnalysisSerializer
 
-    filter_class = emg_filters.AnalysisJobFilter
+    filterset_class = emg_filters.AnalysisJobFilter
 
     filter_backends = (
         DjangoFilterBackend,

--- a/emgapianns/viewsets.py
+++ b/emgapianns/viewsets.py
@@ -64,7 +64,7 @@ class AnalysisRelationshipViewSet(ListReadOnlyModelViewSet):
     """
     serializer_class = emg_serializers.AnalysisSerializer
 
-    filter_class = emg_filters.AnalysisJobFilter
+    filterset_class = emg_filters.AnalysisJobFilter
 
     filter_backends = (
         DjangoFilterBackend,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
 # dev tools
-django-debug-toolbar==3.2.2
-django-extensions==3.1.3
+django-debug-toolbar==3.8.1
+django-extensions==3.2.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,5 @@
-# py3.4
-multidict==4.5.2; python_version < '3.5'
-pytest==4.6.11; python_version < '3.5'
-
-multidict==5.1.0; python_version > '3.4'
-pytest==6.2.5; python_version > '3.4'
+multidict==5.1.0
+pytest==6.2.5
 
 pytest-django==4.4.0
 pytest-xdist==2.3.0
@@ -13,8 +9,6 @@ mongomock==3.23.0
 jsonapi-client==0.9.9
 pytest-cov==2.12.1
 
-pandas==0.25.3; python_version < '3.7'
-pandas==1.3.2; python_version > '3.6'
+pandas==1.3.2
 
-responses==0.10.15; python_version < '3.5'
-responses==0.13.4; python_version > '3.4'
+responses==0.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ PyYAML==6.0
 concurrent-log-handler~=0.9.22
 
 Django==3.2.18
-djangorestframework==3.14.0
+djangorestframework==3.12
 django-filter==23.1
 djangorestframework-jwt~=1.11.0
 django-cors-headers==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,50 +3,44 @@
 # run pip install -r requirements
 
 # deployment
-gunicorn==19.9.0; python_version < '3.5'
-whitenoise==3.3.1; python_version < '3.5'
-mysqlclient==1.3.13; python_version < '3.5'
-sqlparse==0.2.4; python_version < '3.5'
-requests==2.21.0; python_version < '3.5'
 
-gunicorn==20.0.4; python_version > '3.4'
-mysqlclient==1.4.6; python_version > '3.4'
+gunicorn==20.1.0
+mysqlclient==2.1.1
 mysql-connector-python~=8.0.23
-sqlparse==0.3.1; python_version > '3.4'
-whitenoise==5.0.1; python_version > '3.4'
-requests==2.26.0; python_version > '3.4'
+sqlparse==0.4.3
+whitenoise==6.4.0
+requests==2.28.2
 
 yamjam==0.1.7
 # python 3.4
-PyYAML==5.4.1
+PyYAML==6.0
 
 # log handler
-concurrent-log-handler~=0.9.19
+concurrent-log-handler~=0.9.22
 
-Django==3.2.12
-djangorestframework==3.12.4
-django-filter==2.4.0
+Django==3.2.18
+djangorestframework==3.14.0
+django-filter==23.1
 djangorestframework-jwt~=1.11.0
-django-cors-headers==3.8.0
+django-cors-headers==3.14.0
 djangorestframework-jsonapi==4.2.1
 cx_Oracle~=6.2.1
 
 djangorestframework-csv==2.1.1
 
 # schema
-drf-spectacular==0.21.1
+drf-spectacular==0.26.0
 
 # mongo
-mongoengine==0.23.1
-pymongo==3.12.0
+mongoengine==0.27.0
+pymongo==4.3.3
 django-rest-framework-mongoengine==3.4.1
 
 # assembly viewer
-pysam==0.15.3; python_version < '3.5'
-pysam==0.18.0; python_version > '3.4'
+pysam==0.21.0
 
 # sourmash search
-celery[redis]==5.1.0
+celery[redis]==5.2.7
 
 # my-sql utils
 django-mysql==4.3.0


### PR DESCRIPTION
This PR:
- is followup to #294 
- adds support for importing [RO-Crates](https://www.researchobject.org/ro-crate/) as `AssemblyExtraAnnotation`s.
  - as far as the API is concerned, the RO-Crates are just .zip files indexed to an assembly. 
  - they could contain anything... but we have a [proof of concept](https://gist.github.com/SandyRogers/36f04c12739a0bf7a644c4cf218232c7) for the kind of schema/profile they should use.
- upgrades Django and associated packages