### PR TITLE
Vega Related Changes - Addition of Header

### DIFF
--- a/emgapi/views.py
+++ b/emgapi/views.py
@@ -931,7 +931,10 @@ class AnalysisQCChartViewSet(mixins.RetrieveModelMixin,
         if os.path.isfile(filepath):
             logger.info("Path %r" % filepath)
             with open(filepath, "r") as f:
-                return Response(f.read())
+                data = f.read()
+                if chart!="nucleotide-distribution":
+                    data = "key\tvalue" + "\n" + data
+                return Response( data)
         raise Http404()
 
 


### PR DESCRIPTION
@SandyRogers @mberacochea 

This PR is created to include code to generate _tsv files with headers_ for `AnalysisQCChartViewSet`.

This includes endpoints such as => `gc-distribution`, `nucleotide-distribution`, `seq-length` and `summary` .

The changes have been brought because the proposed Charting library for EBI website **Vega** expects the data to have headers. 