### PR TITLE
Workaround to query ENA / ERAPRO Views.

### DIFF
--- a/emgena/models.py
+++ b/emgena/models.py
@@ -194,12 +194,20 @@ class Study(models.Model):
 
 class RunStudy(StudyAbstract):
     class Meta(StudyAbstract.Meta):
-        db_table = 'V_MGP_RUN_STUDY'
+        # ERA needs to be appended as the default connection tries to use
+        # the PUBLIC SYNONYM (according to ENA) and it's not working ATM
+        # we were advised to prefix the views and this is the simplest way.
+        # The short-term plan is to remove the dependency of ENA databases 
+        db_table = 'ERA\".\"V_MGP_RUN_STUDY'
 
 
 class AssemblyStudy(StudyAbstract):
     class Meta(StudyAbstract.Meta):
-        db_table = 'V_MGP_ASSEMBLY_STUDY'
+        # ERA needs to be appended as the default connection tries to use
+        # the PUBLIC SYNONYM (according to ENA) and it's not working ATM
+        # we were advised to prefix the views and this is the simplest way.
+        # The short-term plan is to remove the dependency of ENA databases 
+        db_table = 'ERA\".\"V_MGP_ASSEMBLY_STUDY'
 
 
 class Project(models.Model):


### PR DESCRIPTION
ERA needs to be appended as the default connection tries to use the PUBLIC SYNONYM (according to ENA) and it's not working ATM we were advised to prefix the views and this is the simplest way. The short-term plan is to remove the dependency of ENA databases