### PR TITLE
Fixes regression bug due to ERA Tablespace workaround

### DIFF
--- a/config/local-lite.yml
+++ b/config/local-lite.yml
@@ -9,6 +9,7 @@ emg:
     era:
       ENGINE: 'django.db.backends.sqlite3'
       NAME: '/opt/ci/testdbs/ena-testdb.sqlite'
+      ERA_TABLESPACE_PREFIX: ''
 
   admin: True
   downloads_bypass_nginx: True

--- a/emgena/models.py
+++ b/emgena/models.py
@@ -27,7 +27,9 @@
 from __future__ import unicode_literals
 
 from datetime import date
-from django.db import models, NotSupportedError
+
+from django.conf import settings
+from django.db import models
 
 
 class Status(models.IntegerChoices):
@@ -197,8 +199,9 @@ class RunStudy(StudyAbstract):
         # ERA needs to be appended as the default connection tries to use
         # the PUBLIC SYNONYM (according to ENA) and it's not working ATM
         # we were advised to prefix the views and this is the simplest way.
-        # The short-term plan is to remove the dependency of ENA databases 
-        db_table = 'ERA\".\"V_MGP_RUN_STUDY'
+        # The short-term plan is to remove the dependency of ENA databases
+        _prefix_workaround = settings.DATABASES['era'].get('ERA_TABLESPACE_PREFIX', 'ERA\".\"')
+        db_table = f'{_prefix_workaround}V_MGP_RUN_STUDY'
 
 
 class AssemblyStudy(StudyAbstract):

--- a/emgena/models.py
+++ b/emgena/models.py
@@ -200,7 +200,7 @@ class RunStudy(StudyAbstract):
         # the PUBLIC SYNONYM (according to ENA) and it's not working ATM
         # we were advised to prefix the views and this is the simplest way.
         # The short-term plan is to remove the dependency of ENA databases
-        _prefix_workaround = settings.DATABASES['era'].get('ERA_TABLESPACE_PREFIX', 'ERA\".\"')
+        _prefix_workaround = settings.DATABASES.get('era', {}).get('ERA_TABLESPACE_PREFIX', 'ERA\".\"')
         db_table = f'{_prefix_workaround}V_MGP_RUN_STUDY'
 
 


### PR DESCRIPTION
This PR:
- fixes the ability for the mgnify-web Taskfile task to automatically create a text DB fixture.
- the inability to do so was a regression bug, introduced by a workaround needed for the ERA tablespace on ENA's Oracle DB, which recently stopped routing Views automatically to the default tablespace. Unforunately, SQlite doesn't support `.` in table names, or tablespaces, so our "fake" ENA database can't perfectly match ERA. This adds a workaround for that.