### PR TITLE
Setting cookies after jwt auth obtain call is made

### DIFF
--- a/emgcli/settings.py
+++ b/emgcli/settings.py
@@ -518,6 +518,7 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
 JWT_AUTH = {
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=108000),
     'JWT_AUTH_HEADER_PREFIX': 'Bearer',
+    'JWT_AUTH_COOKIE': 'EMG_AUTH',
 }
 
 try:


### PR DESCRIPTION
It has been observed that the downloading private studies has been failing due to authentication problems. 
Since we updated the APIs to work with JWT based auth, the private study downloads seemed to have been affected by this.
This Pull request addresses this issue by adding an auth cookie, when a JWT token is obtained from the API.