### PR TITLE
Hotfix/emg auth cookie

### DIFF
--- a/emgcli/__init__.py
+++ b/emgcli/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "2.4.40"
+__version__: str = "2.4.41"

--- a/emgcli/settings.py
+++ b/emgcli/settings.py
@@ -528,8 +528,7 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
 
 JWT_AUTH = {
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=108000),
-    'JWT_AUTH_HEADER_PREFIX': 'Bearer',
-    'JWT_AUTH_COOKIE': 'EMG_AUTH',
+    'JWT_AUTH_HEADER_PREFIX': 'Bearer'
 }
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ max-line-length = 119
 """
 
 [tool.bumpversion]
-current_version = "2.4.40"
+current_version = "2.4.41"
 
 [[tool.bumpversion.files]]
 filename = "emgcli/__init__.py"


### PR DESCRIPTION
Removed the EMG_AUTH cookie. As this is no longer required since the bearer auth token is now going to be added when private file downloads are triggered on the frontend