### PR TITLE
Bugfix/run accession for assembly

### DIFF
--- a/emgapianns/management/lib/utils.py
+++ b/emgapianns/management/lib/utils.py
@@ -44,8 +44,7 @@ def get_run_accession(path):
     match = re.search(pattern, path)
     if match:
         if len(match.groups()) > 0:
-            end_pos = match.end()
-            return path[0:end_pos]
+            return match.groups()[0]
         else:
             raise Exception("Could not identify run accession from {}".format(path))
     else:

--- a/emgcli/__init__.py
+++ b/emgcli/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "2.4.50"
+__version__: str = "2.4.51"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ max-line-length = 119
 """
 
 [tool.bumpversion]
-current_version = "2.4.50"
+current_version = "2.4.51"
 
 [[tool.bumpversion.files]]
 filename = "emgcli/__init__.py"

--- a/tests/webuploader/test_import_assembly.py
+++ b/tests/webuploader/test_import_assembly.py
@@ -24,6 +24,8 @@ from emgapianns.management.commands.import_assembly import Command
 
 from model_bakery import baker
 
+from emgapianns.management.lib.utils import get_run_accession
+
 
 def bake_models(coverage=None, min_gap_length=None):
     """Build the required models for import_assembly
@@ -109,3 +111,10 @@ class TestImportAssembly:
         assert emg_assembly.is_private == False
         assert emg_assembly.wgs_accession == ena_assembly.wgs_accession
         assert emg_assembly.legacy_accession == ena_assembly.gc_id
+
+    def test_run_accession_getter(self):
+        assert get_run_accession("ERR1111111") == "ERR1111111"
+        assert get_run_accession("ERR1111111;ERR1111112") == "ERR1111111"  # first only
+        assert get_run_accession("PREFIX_ERR1111111") == "ERR1111111"  # only accession part
+        assert get_run_accession("ERR1111111_SUFFIX") == "ERR1111111"
+        assert get_run_accession("NOPE;PREFIX_ERR1111111_SUFFIX;PREFIX_ERR1111112_SUFFIX;ALSONOPE") == "ERR1111111"  # complete edge case


### PR DESCRIPTION
Handle cases where an assembly has run name metadata like `ABC_SRR1234567`; i.e. a valid run accession exists but in an unexpected form.