### PR TITLE
change to run study and assembly study model for cases where one project accession doesn't work

### DIFF
--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -222,7 +222,7 @@ class StudyImporter:
                 study_id=project_id)
             return project
         except ena_models.AssemblyStudy.DoesNotExist:
-            logging.warning(f"No ENA project found for {project_id}")
+            logging.warning(f"No ENA project found in ena_models.AssemblyStudy for {project_id}")
         return None
 
 

--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -212,14 +212,19 @@ class StudyImporter:
     def _get_ena_project(ena_db, project_id):
         # return ena_models.Project.objects.using(ena_db).get(project_id=project_id)
         try:
-            project = ena_models.Project.objects.using(ena_db).get(
-                project_id=project_id
-            )
-        except ena_models.Project.DoesNotExist:
-            logging.warning(f"No ENA project found for {project_id}")
-            return None
-        else:
+            project = ena_models.RunStudy.objects.using(ena_db).get(
+                study_id=project_id)
             return project
+        except ena_models.RunStudy.DoesNotExist:
+            logging.warning(f"No ENA run project found for {project_id}")
+        try:
+            project = ena_models.AssemblyStudy.objects.using(ena_db).get(
+                study_id=project_id)
+            return project
+        except ena_models.AssemblyStudy.DoesNotExist:
+            logging.warning(f"No ENA project found for {project_id}")
+        return None
+
 
     def _update_or_create_study_from_api_result(
         self, api_study, study_result_dir, lineage, ena_db, emg_db

--- a/emgapianns/management/lib/create_or_update_study.py
+++ b/emgapianns/management/lib/create_or_update_study.py
@@ -216,7 +216,7 @@ class StudyImporter:
                 study_id=project_id)
             return project
         except ena_models.RunStudy.DoesNotExist:
-            logging.warning(f"No ENA run project found for {project_id}")
+            logging.warning(f"No ENA run project found in ena_models.RunStudy for {project_id}")
         try:
             project = ena_models.AssemblyStudy.objects.using(ena_db).get(
                 study_id=project_id)


### PR DESCRIPTION
Modified searching for project data from Project model to try both RunStudy and AssemblyStudy. This is because Project does not contain a field for secondary accessions containing "RP" and we have edge cases where only secondary accessions exists and no "PRJ" primary accession.